### PR TITLE
feat(#80): 로그인 토큰 저장 후 홈페이지 입장 구현

### DIFF
--- a/src/features/auth/api/auth_api.ts
+++ b/src/features/auth/api/auth_api.ts
@@ -8,6 +8,7 @@ import type {
   SocialLoginRequest,
 } from "./auth_types";
 import type { TokenDto } from "@/shared/api/shared_types";
+import { tokenUtils } from "@/shared/api/client";
 
 // ============================================================
 // 환경변수 (카카오 로그인용)
@@ -31,10 +32,22 @@ export const loginWithKakao = async (
 ): Promise<ApiResponse<LoginResult>> => {
   const response = await apiClient.post<ApiResponse<LoginResult>>(
     `${AUTH_BASE}/login/kakao`,
-    {
-      authorizationCode: code,
-    },
+    { authorizationCode: code },
   );
+
+  const result = response.data.result;
+
+  // 💡 데이터가 오는지 확인하기 위해 잠시 '알림창'을 띄워보세요.
+  if (response.data.isSuccess && result) {
+    // 백엔드 응답 구조에 따라 토큰을 안전하게 추출
+    const accessToken = result.token?.accessToken || result.accessToken;
+    const refreshToken = result.token?.refreshToken || result.refreshToken;
+
+    if (accessToken && refreshToken) {
+      tokenUtils.setTokens(accessToken, refreshToken);
+      console.log("✅ 토큰 저장 성공:", accessToken.substring(0, 10) + "...");
+    }
+  }
   return response.data;
 };
 

--- a/src/features/auth/api/auth_types.ts
+++ b/src/features/auth/api/auth_types.ts
@@ -101,6 +101,8 @@ export interface LogoutRequest {
 
 /** 로그인 결과 데이터 */
 export interface LoginResult {
+  accessToken: string;
+  refreshToken: string;
   loginType: "LOGIN" | "SIGNUP_REQUIRED";
   user?: UserDto;
   token?: TokenDto;

--- a/src/features/auth/pages/KakaoCallbackPage.tsx
+++ b/src/features/auth/pages/KakaoCallbackPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { loginWithKakao } from "../api/auth_api";
+import { AxiosError } from "axios";
 import { useAuthStore } from "../store/auth_store";
 
 export const KakaoCallbackPage = () => {
@@ -28,19 +29,32 @@ export const KakaoCallbackPage = () => {
       try {
         const data = await loginWithKakao(code);
 
-        if (data.isSuccess) {
+        if (data.isSuccess && data.result) {
           login(data.result);
-          navigate("/signup", {
-            state: { kakaoInfo: data.result.kakaoInfo },
-          });
+
+          if (data.result.loginType === "SIGNUP_REQUIRED") {
+            navigate("/signup", {
+              state: {
+                kakaoInfo: data.result.kakaoInfo,
+                signupToken: data.result.signupToken,
+              },
+            });
+          } else {
+            navigate("/");
+          }
         } else {
           alert(`로그인 실패: ${data.message}`);
           navigate("/login");
         }
-      } catch (error: any) {
-        if (error.response) {
+      } catch (error) {
+        const axiosError = error as AxiosError<{ message?: string }>;
+
+        if (axiosError.response) {
           alert(
-            `로그인 실패 (${error.response.status}): ${error.response.data?.message || "서버에서 오류가 발생했습니다."}`,
+            `로그인 실패 (${axiosError.response.status}): ${
+              axiosError.response.data?.message ||
+              "서버에서 오류가 발생했습니다."
+            }`,
           );
         } else {
           alert("로그인 처리 중 오류가 발생했습니다.");

--- a/src/features/auth/store/auth_store.ts
+++ b/src/features/auth/store/auth_store.ts
@@ -18,10 +18,26 @@ export const useAuthStore = create<AuthState>()(
       token: null,
       isAuthenticated: false,
       login: (result) => {
+        // 1. 토큰 데이터 추출 (객체 안 혹은 바로 아래)
+        const accessToken = result.token?.accessToken || result.accessToken;
+        const refreshToken = result.token?.refreshToken || result.refreshToken;
+        const accessTokenExpiresIn = result.token?.accessTokenExpiresIn || 0;
+        const refreshTokenExpiresIn = result.token?.refreshTokenExpiresIn || 0;
+
+        const hasToken = !!accessToken;
+
         set({
           user: result.user ?? null,
-          token: result.token ?? null,
-          isAuthenticated: !!result.token,
+          // 2. TokenDto 타입 규격 완벽 일치시키기
+          token: hasToken
+            ? {
+                accessToken: accessToken as string,
+                refreshToken: (refreshToken as string) || "",
+                accessTokenExpiresIn: accessTokenExpiresIn,
+                refreshTokenExpiresIn: refreshTokenExpiresIn,
+              }
+            : null,
+          isAuthenticated: hasToken,
         });
       },
       logout: () => {
@@ -33,10 +49,11 @@ export const useAuthStore = create<AuthState>()(
       },
     }),
     {
-      name: "auth-storage", // localStorage Key
+      name: "auth-storage",
       storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         user: state.user,
+        token: state.token,
         isAuthenticated: state.isAuthenticated,
       }),
     },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,22 +6,22 @@ import { router } from "./app/router/routes";
 import "./app/styles/global.css";
 
 // MSW 개발 환경에서만 활성화
-const enableMocking = async () => {
-  if (import.meta.env.DEV) {
-    const { worker } = await import("./mocks/browser");
-    return worker.start({
-      onUnhandledRequest: "bypass", // 미처리 요청은 실제 서버로 전달
-    });
-  }
-  return Promise.resolve();
-};
+// const enableMocking = async () => {
+//   if (import.meta.env.DEV) {
+//     const { worker } = await import("./mocks/browser");
+//     return worker.start({
+//       onUnhandledRequest: "bypass", // 미처리 요청은 실제 서버로 전달
+//     });
+//   }
+//   return Promise.resolve();
+// };
 
-enableMocking().then(() => {
-  createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <AppQueryProvider>
-        <RouterProvider router={router} />
-      </AppQueryProvider>
-    </StrictMode>,
-  );
-});
+// enableMocking().then(() => {
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <AppQueryProvider>
+      <RouterProvider router={router} />
+    </AppQueryProvider>
+  </StrictMode>,
+);
+// });

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -30,6 +30,23 @@ export const apiClient = axios.create({
   },
 });
 
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+}> = [];
+
+const processQueue = (
+  error: AxiosError | null,
+  token: string | null = null,
+) => {
+  failedQueue.forEach((prom) => {
+    if (error) prom.reject(error);
+    else prom.resolve(token);
+  });
+  failedQueue = [];
+};
+
 // Request Interceptor - 토큰 자동 첨부
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
@@ -42,27 +59,7 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error),
 );
 
-// Response Interceptor - 토큰 만료 시 자동 갱신
-let isRefreshing = false;
-let failedQueue: Array<{
-  resolve: (value: unknown) => void;
-  reject: (reason?: unknown) => void;
-}> = [];
-
-const processQueue = (
-  error: AxiosError | null,
-  token: string | null = null,
-) => {
-  failedQueue.forEach((prom) => {
-    if (error) {
-      prom.reject(error);
-    } else {
-      prom.resolve(token);
-    }
-  });
-  failedQueue = [];
-};
-
+// Response Interceptor - 토큰 만료 및 에러 처리
 apiClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
@@ -70,10 +67,27 @@ apiClient.interceptors.response.use(
       _retry?: boolean;
     };
 
-    // 401 에러이고 재시도하지 않은 요청인 경우
+    // 1. 로그인 관련 API는 즉시 거절 (무한 리다이렉트 방지)
+    if (originalRequest.url?.includes("/api/auth/login/kakao")) {
+      return Promise.reject(error);
+    }
+
+    // 2. 401 에러(인증 만료) 처리 시작
     if (error.response?.status === 401 && !originalRequest._retry) {
+      // 💡 [수정] 변수 이름이 아니라 utils를 통해 실제 값을 가져와야 합니다.
+      const storedRefreshToken = tokenUtils.getRefreshToken();
+
+      // 💡 [중요] 리프레시 토큰이 없으면 리다이렉트하지 않고 조용히 에러만 던집니다.
+      // 이렇게 해야 로그인 직후 튕기는 현상을 막을 수 있습니다.
+      if (!storedRefreshToken) {
+        console.warn(
+          "[Auth] 인증 필요 - 리프레시 토큰 없음 (로그인 페이지로 튕기지 않음)",
+        );
+        return Promise.reject(error);
+      }
+
+      // 이미 토큰 갱신 중인 경우 큐에 추가
       if (isRefreshing) {
-        // 이미 토큰 갱신 중이면 큐에 추가
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
         })
@@ -87,27 +101,17 @@ apiClient.interceptors.response.use(
       originalRequest._retry = true;
       isRefreshing = true;
 
-      const refreshToken = tokenUtils.getRefreshToken();
-
-      if (!refreshToken) {
-        // 개발 환경에서는 리다이렉트하지 않음 (MSW 사용)
-        if (import.meta.env.DEV) {
-          console.warn("[Auth] 토큰 없음 - 개발 환경에서는 리다이렉트 스킵");
-          return Promise.reject(error);
-        }
-        tokenUtils.clearTokens();
-        window.location.href = "/login";
-        return Promise.reject(error);
-      }
-
       try {
+        // 실제 토큰 갱신 요청
         const response = await axios.post<ApiResponse<TokenDto>>(
           `${BASE_URL}/api/auth/token/refresh`,
-          { refreshToken },
+          { refreshToken: storedRefreshToken },
         );
 
         const { accessToken, refreshToken: newRefreshToken } =
           response.data.result;
+
+        // 새로운 토큰들 저장
         tokenUtils.setTokens(accessToken, newRefreshToken);
 
         processQueue(null, accessToken);
@@ -116,7 +120,8 @@ apiClient.interceptors.response.use(
         return apiClient(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError as AxiosError, null);
-        // 개발 환경에서는 리다이렉트하지 않음 (MSW 사용)
+
+        // 갱신 자체에 실패한 경우에만 로그인 페이지로 보냅니다 (배포 환경)
         if (!import.meta.env.DEV) {
           tokenUtils.clearTokens();
           window.location.href = "/login";


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #80 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 로그인 토큰 저장 후 홈페이지 입장 구현

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 토큰 자동 갱신 기능 추가로 사용자 세션 연속성 개선

* **버그 수정**
  * 로그인 플로우의 토큰 처리 로직 강화
  * 카카오 로그인 후 토큰 저장 프로세스 개선
  * 로그인 실패 시 에러 메시지 및 안내 개선
  * 회원가입 필요 시 적절한 페이지 리다이렉트 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->