### PR TITLE
[Fix] naver state 저장 기능 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,10 @@ jobs:
           VITE_APP_BASE_URL: ${{ secrets.VITE_APP_BASE_URL }}
           VITE_KAKAO_CLIENT_ID: ${{ secrets.VITE_KAKAO_CLIENT_ID }}
           VITE_KAKAO_REDIRECT_URI: ${{ secrets.VITE_KAKAO_REDIRECT_URI }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_GOOGLE_REDIRECT_URI: ${{ secrets.VITE_GOOGLE_REDIRECT_URI }}
+          VITE_NAVER_CLIENT_ID: ${{ secrets.VITE_NAVER_CLIENT_ID }}
+          VITE_NAVER_REDIRECT_URI: ${{ secrets.VITE_NAVER_REDIRECT_URI }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -22,8 +22,12 @@ export const LoginPage = () => {
       const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
       window.location.href = kakaoAuthUrl;
     } else if (provider === "naver") {
-      // 네이버는 state 값이 필수 (CSRF 방지용 랜덤 문자열)
-      const state = Math.random().toString(36).substring(2, 15);
+      // 네이버는 state 값이 필수 (CSRF 방지용 - 암호학적으로 안전한 난수 생성)
+      const state =
+        crypto.randomUUID?.() ??
+        Array.from(crypto.getRandomValues(new Uint8Array(16)))
+          .map((byte) => byte.toString(16).padStart(2, "0"))
+          .join("");
       // state를 sessionStorage에 저장하여 콜백에서 검증
       sessionStorage.setItem("naver_oauth_state", state);
       const naverAuthUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${NAVER_REDIRECT_URI}&state=${state}`;

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -24,6 +24,8 @@ export const LoginPage = () => {
     } else if (provider === "naver") {
       // 네이버는 state 값이 필수 (CSRF 방지용 랜덤 문자열)
       const state = Math.random().toString(36).substring(2, 15);
+      // state를 sessionStorage에 저장하여 콜백에서 검증
+      sessionStorage.setItem("naver_oauth_state", state);
       const naverAuthUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${NAVER_REDIRECT_URI}&state=${state}`;
       window.location.href = naverAuthUrl;
     } else if (provider === "google") {

--- a/src/features/auth/pages/NaverCallbackPage.tsx
+++ b/src/features/auth/pages/NaverCallbackPage.tsx
@@ -23,6 +23,18 @@ export const NaverCallbackPage = () => {
       return;
     }
 
+    // state 검증: 저장된 state와 비교
+    const savedState = sessionStorage.getItem("naver_oauth_state");
+    if (!savedState || savedState !== state) {
+      alert("로그인 실패: state 값이 일치하지 않습니다. (CSRF 공격 방지)");
+      sessionStorage.removeItem("naver_oauth_state");
+      navigate("/login");
+      return;
+    }
+
+    // 검증 완료 후 state 제거
+    sessionStorage.removeItem("naver_oauth_state");
+
     const processLogin = async () => {
       try {
         const data = await loginWithNaver(code, state);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #92

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 네이버 OAuth 로그인 시 생성한 `state` 값이 저장되지 않아 콜백 단계에서 401이 발생하던 문제 수정
- `LoginPage.tsx`에서 네이버 로그인 요청 시 생성한 state를 `sessionStorage`에 저장하도록 추가
- `NaverCallbackPage.tsx`에서 콜백으로 받은 state와 저장된 state를 비교 검증 로직 추가
- state 불일치 시 로그인 중단 및 에러 안내 후 로그인 페이지로 이동 처리
- 검증 완료 후 `sessionStorage`의 state 값 제거하도록 처리 (재사용 방지)

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 현재 프론트엔드에서 state를 저장/검증하도록 수정했습니다.
- 백엔드 `/api/auth/login/naver`에서 state를 별도로 검증하고 있다면 세션 기반 state 저장 로직이 있는지 추가 확인이 필요합니다.
- 서버에서도 state 검증을 강제하는 구조라면, 추후 “서버 생성 state 사용” 방식으로 OAuth 플로우를 맞추는 개선이 필요할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 빌드 환경에 Google 및 Naver 클라이언트 ID 및 리디렉트 URI 관련 환경변수 추가

* **버그 수정**
  * Naver 소셜 로그인 시 상태(state) 생성 방식 강화(암호학적 난수 사용 및 저장)
  * 콜백에서 클라이언트 측 상태 검증 추가: 불일치 시 인증 중단 후 로그인 화면으로 이동 및 저장 상태 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->