### PR TITLE
Refactor(#62): 노트목록 페이지 반응형 및 정렬 버튼 구현

### DIFF
--- a/src/features/notes/pages/NotesPage.tsx
+++ b/src/features/notes/pages/NotesPage.tsx
@@ -157,10 +157,18 @@ export const NotesPage = () => {
 
   return (
     <div className="flex h-full w-full flex-col overflow-auto bg-white">
-      {/* 사이드바를 제외한 나머지 영역에서 가운데 정렬을 위한 컨테이너 */}
-      <div className="mx-auto flex w-full max-w-[1200px] flex-1 flex-col px-8">
-        {/* 본문(정렬/그리드/페이지네이션) 묶음: 세로/가로 모두 가운데 정렬 */}
-        <div className="mx-auto my-auto w-full max-w-[893px]">
+      {/* 사이드바를 제외한 나머지 영역에서 가운데 정렬을 위한 컨테이너
+          - 좌우 패딩 80px(px-20)을 기준으로 전체 레이아웃을 잡고,
+          - 실제 노트 영역(제목/정렬바/그리드/페이지네이션)은
+            카드 열 개수(2열/3열)에 맞는 고정 너비 컨테이너 안에서만 움직이도록 설정 */}
+      <div className="mx-auto flex w-full flex-1 flex-col px-20">
+        {/* 본문(정렬/그리드/페이지네이션) 묶음
+            - 노트 카드가 2개일 때 기준 너비: 2 * 271 + 1 * 40 = 582px
+            - 노트 카드가 3개일 때 기준 너비: 3 * 271 + 2 * 40 = 893px
+            - 이 컨테이너 너비 안에서만 제목/정렬바/노트 개수/카드 그리드가 움직이도록 고정
+            - "디자인 기준 화면 크기"보다 작아지는 순간 바로 2열로 떨어지도록,
+              3열 전환 시점을 더 보수적으로(min-[1340px]) 설정 */}
+        <div className="mx-auto my-auto w-[582px] min-[1340px]:w-[893px]">
           {/* 헤더 영역 */}
           <div>
             {/* 제목 */}
@@ -233,9 +241,15 @@ export const NotesPage = () => {
           <div>
             {/* 정렬 버튼과 노트 추가하기 카드 사이 간격 21px */}
             <div className="mt-[21px] w-full">
+              {/* 노트 블록 크기(271x229)와 블록 간 간격(40px)은 고정
+                  - 이 컨테이너의 너비와 정확히 맞도록 열 개수(2→3)를 변경
+                  - min-[1340px] 이상에서만 3열을 사용하고,
+                    그보다 작아지는 순간 바로 2열로 떨어지게 해서
+                    카드가 좌우 여백(80px)까지 닿지 않도록 함 */}
               <div
-                className="grid gap-[40px]"
-                style={{ gridTemplateColumns: "271px 271px 271px" }}
+                className="grid gap-[40px]
+                  [grid-template-columns:repeat(2,271px)]
+                  min-[1340px]:[grid-template-columns:repeat(3,271px)]"
               >
                 {/* 노트 추가하기 카드 */}
                 <Link

--- a/src/features/notes/pages/NotesPage.tsx
+++ b/src/features/notes/pages/NotesPage.tsx
@@ -59,6 +59,13 @@ interface Note {
   lastUsedAt: string;
 }
 
+type SortOrder =
+  | "recentUsed" // 최근 사용 순 (기본값)
+  | "createdDesc" // 최신 생성 순
+  | "createdAsc" // 오래된 생성 순
+  | "nameAsc" // 이름 순
+  | "nameDesc"; // 이름 역순
+
 export const NotesPage = () => {
   // TODO: useNotes() 훅으로 노트 목록 fetch
   const mockNotes: Note[] = [
@@ -99,6 +106,55 @@ export const NotesPage = () => {
   const totalNotes = 5;
   const currentNotes = 3;
 
+  const [sortOrder, setSortOrder] = useState<SortOrder>("recentUsed");
+  const [isSortDropdownOpen, setIsSortDropdownOpen] = useState(false);
+
+  const sortOptions: { value: SortOrder; label: string }[] = [
+    { value: "recentUsed", label: "최근 사용 순" },
+    { value: "createdDesc", label: "최신 생성 순" },
+    { value: "createdAsc", label: "오래된 생성 순" },
+    { value: "nameAsc", label: "이름 순" },
+    { value: "nameDesc", label: "이름 역순" },
+  ];
+
+  const sortedNotes = [...mockNotes].sort((a, b) => {
+    switch (sortOrder) {
+      case "recentUsed": {
+        // 최근 사용 순: lastUsedAt 내림차순
+        return (
+          new Date(b.lastUsedAt).getTime() - new Date(a.lastUsedAt).getTime()
+        );
+      }
+      case "createdDesc": {
+        // 최신 생성 순: createdAt 내림차순
+        return (
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+      }
+      case "createdAsc": {
+        // 오래된 생성 순: createdAt 오름차순
+        return (
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
+      }
+      case "nameAsc": {
+        // 이름 순: 가나다순
+        return a.title.localeCompare(b.title, "ko");
+      }
+      case "nameDesc": {
+        // 이름 역순
+        return b.title.localeCompare(a.title, "ko");
+      }
+      default:
+        return 0;
+    }
+  });
+
+  const handleSelectSort = (value: SortOrder) => {
+    setSortOrder(value);
+    setIsSortDropdownOpen(false);
+  };
+
   return (
     <div className="flex h-full w-full flex-col overflow-auto bg-white">
       {/* 사이드바를 제외한 나머지 영역에서 가운데 정렬을 위한 컨테이너 */}
@@ -117,14 +173,46 @@ export const NotesPage = () => {
             {/* 정렬 버튼 + 노트 개수(같은 가로선) */}
             <div className="w-full">
               <div className="flex items-center justify-between">
-                <button className="flex h-[28px] w-[120px] items-center justify-between overflow-hidden rounded-[8px] border-[0.5px] border-[#D1D6DE] bg-white px-[12px] py-[10px] transition-colors hover:bg-gray-50">
-                  <span className="font-['Noto_Sans_KR',sans-serif] text-[14px] leading-[15px] font-normal whitespace-nowrap text-[#2F3440]">
-                    정렬
-                  </span>
-                  <span className="h-[16px] w-[16px] shrink-0">
-                    <DropdownIcon className="h-full w-full text-[#2F3440]" />
-                  </span>
-                </button>
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setIsSortDropdownOpen((prevIsOpen) => !prevIsOpen)
+                    }
+                    className="flex h-[28px] w-[140px] items-center justify-between overflow-hidden rounded-[8px] border-[0.5px] border-[#D1D6DE] bg-white px-[12px] py-[10px] transition-colors hover:bg-gray-50"
+                  >
+                    <span className="font-['Noto_Sans_KR',sans-serif] text-[14px] leading-[15px] font-normal whitespace-nowrap text-[#2F3440]">
+                      {sortOptions.find((option) => option.value === sortOrder)
+                        ?.label ?? "정렬"}
+                    </span>
+                    <span className="h-[16px] w-[16px] shrink-0">
+                      <DropdownIcon
+                        className={`h-full w-full text-[#2F3440] transition-transform ${
+                          isSortDropdownOpen ? "rotate-180" : ""
+                        }`}
+                      />
+                    </span>
+                  </button>
+
+                  {isSortDropdownOpen && (
+                    <div className="absolute right-0 z-10 mt-[4px] w-[192px] rounded-[8px] border border-[#D1D6DE] bg-white py-[4px] shadow-[0_8px_20px_rgba(0,0,0,0.08)]">
+                      {sortOptions.map((option) => (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => handleSelectSort(option.value)}
+                          className={`mx-[4px] flex w-[calc(100%-8px)] items-center rounded-[8px] px-[12px] py-[8px] text-left text-[13px] leading-[18px] transition-shadow ${
+                            sortOrder === option.value
+                              ? "border border-[#2A6AFF] font-medium text-[#003880]"
+                              : "text-[#2F3440] hover:shadow-[0_0_0_3px_rgba(42,106,255,0.15)]"
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
 
                 <div className="flex items-center gap-[8px]">
                   <span className="text-[16px] leading-[20px] font-medium text-black">
@@ -168,7 +256,7 @@ export const NotesPage = () => {
                 </Link>
 
                 {/* 노트 카드들 */}
-                {mockNotes.map((note) => (
+                {sortedNotes.map((note) => (
                   <Link
                     key={note.id}
                     to={`/app/chat/${note.id}`}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #62 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 노트 목록 페이지의 정렬 드롭다운 버튼 구현
- 노트 목록 페이지의 화면 비율에 따른 반응형 구현

## 📸 스크린샷

https://github.com/user-attachments/assets/ead4e3f9-86d7-41e8-acb3-ed111b447f85


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 노트 목록에 정렬 기능 추가: 최근 사용, 생성일(오름차순/내림차순), 이름(오름차순/내림차순) 등 여러 정렬 기준 제공
  * 정렬 옵션 선택 드롭다운 UI 추가
  * 반응형 그리드 레이아웃 개선으로 화면 크기에 따라 2단 또는 3단 열 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->