### PR TITLE
Feat(#128): 노트 삭제 api연결 및 관련 ui/ux 구현

### DIFF
--- a/src/features/notes/api/notes_api.ts
+++ b/src/features/notes/api/notes_api.ts
@@ -49,3 +49,15 @@ export const getNoteDetail = async (
   );
   return response.data;
 };
+
+// 노트 벌크 삭제
+export const deleteNotesBulk = async (
+  noteIds: number[],
+): Promise<ApiResponse<{ deletedCount: number; deletedNoteIds: number[] }>> => {
+  const response = await apiClient.delete<
+    ApiResponse<{ deletedCount: number; deletedNoteIds: number[] }>
+  >(NOTES_BASE, {
+    data: { noteIds },
+  });
+  return response.data;
+};

--- a/src/features/notes/api/notes_api.ts
+++ b/src/features/notes/api/notes_api.ts
@@ -61,3 +61,25 @@ export const deleteNotesBulk = async (
   });
   return response.data;
 };
+
+// 단일 노트 삭제
+export const deleteNote = async (
+  noteId: number,
+): Promise<
+  ApiResponse<{
+    deletedNoteId: number;
+    deletedConversationCount: number;
+    deletedAssetCount: number;
+    freedStorageBytes: number;
+  }>
+> => {
+  const response = await apiClient.delete<
+    ApiResponse<{
+      deletedNoteId: number;
+      deletedConversationCount: number;
+      deletedAssetCount: number;
+      freedStorageBytes: number;
+    }>
+  >(`${NOTES_BASE}/${noteId}`);
+  return response.data;
+};

--- a/src/features/notes/components/DeleteNotesModal.tsx
+++ b/src/features/notes/components/DeleteNotesModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useDeleteNotesBulk } from "../hooks/useNotes";
+import { useDeleteNote } from "../hooks/useNotes";
 
 interface DeleteNotesModalProps {
   selectedIds: number[];
@@ -13,7 +13,7 @@ export const DeleteNotesModal = ({
   onSuccess,
 }: DeleteNotesModalProps) => {
   const [isDeleting, setIsDeleting] = useState(false);
-  const deleteNotesMutation = useDeleteNotesBulk();
+  const deleteNoteMutation = useDeleteNote();
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget && !isDeleting) {
@@ -24,7 +24,11 @@ export const DeleteNotesModal = ({
   const handleDeleteClick = async () => {
     setIsDeleting(true);
     try {
-      await deleteNotesMutation.mutateAsync(selectedIds);
+      // 각 노트를 병렬로 삭제
+      const deletePromises = selectedIds.map((id) =>
+        deleteNoteMutation.mutateAsync(id),
+      );
+      await Promise.all(deletePromises);
       onSuccess();
     } catch (error) {
       console.error("노트 삭제 실패:", error);

--- a/src/features/notes/components/DeleteNotesModal.tsx
+++ b/src/features/notes/components/DeleteNotesModal.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { useDeleteNotesBulk } from "../hooks/useNotes";
+
+interface DeleteNotesModalProps {
+  selectedIds: number[];
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export const DeleteNotesModal = ({
+  selectedIds,
+  onClose,
+  onSuccess,
+}: DeleteNotesModalProps) => {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const deleteNotesMutation = useDeleteNotesBulk();
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget && !isDeleting) {
+      onClose();
+    }
+  };
+
+  const handleDeleteClick = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteNotesMutation.mutateAsync(selectedIds);
+      onSuccess();
+    } catch (error) {
+      console.error("노트 삭제 실패:", error);
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[#00000033]"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="relative bg-white"
+        style={{
+          width: "560px",
+          height: "360px",
+          borderRadius: "20px",
+          boxShadow: "0px 10px 40px rgba(0, 0, 0, 0.1)",
+        }}
+      >
+        {/* Title Section */}
+        <div
+          className="absolute inset-x-0 mx-auto flex flex-col items-center"
+          style={{ top: "68px", width: "319px" }}
+        >
+          <h2
+            style={{
+              color: "#000",
+              textAlign: "center",
+              fontFamily: "Pretendard",
+              fontSize: "32px",
+              fontStyle: "normal",
+              fontWeight: 600,
+              lineHeight: "48px",
+              letterSpacing: "-0.006px",
+            }}
+          >
+            선택하신 노트{" "}
+            <span style={{ color: "#2542F0", fontWeight: 700 }}>
+              {selectedIds.length}개
+            </span>
+            를
+            <br />
+            삭제하시겠습니까?
+          </h2>
+
+          <p
+            style={{
+              color: "#000",
+              textAlign: "center",
+              fontFamily: "Pretendard",
+              fontSize: "18px",
+              fontStyle: "normal",
+              fontWeight: 400,
+              lineHeight: "28px",
+              letterSpacing: "-0.002px",
+              width: "319px",
+              marginTop: "16px",
+            }}
+          >
+            삭제된 노트는 복구가 불가능합니다.
+          </p>
+        </div>
+
+        {/* Buttons Section */}
+        <div
+          className="absolute inset-x-0 mx-auto flex items-center justify-center"
+          style={{ bottom: "19px", gap: "12px" }}
+        >
+          <button
+            onClick={onClose}
+            disabled={isDeleting}
+            style={{
+              display: "flex",
+              width: "240px",
+              height: "56px",
+              padding: "10px",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: "10px",
+              borderRadius: "20px",
+              border: "1px solid #D1D6DE",
+              background: "#F1F4F8",
+              color: "#6B7280",
+              fontFamily: "Pretendard",
+              fontSize: "18px",
+              fontWeight: 600,
+              cursor: isDeleting ? "not-allowed" : "pointer",
+              opacity: isDeleting ? 0.5 : 1,
+            }}
+          >
+            취소하기
+          </button>
+
+          <button
+            onClick={handleDeleteClick}
+            disabled={isDeleting}
+            style={{
+              display: "flex",
+              width: "240px",
+              height: "56px",
+              padding: "10px",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: "10px",
+              borderRadius: "20px",
+              background: "#2A6AFF",
+              border: "none",
+              color: "#FFF",
+              fontFamily: "Pretendard",
+              fontSize: "18px",
+              fontWeight: 600,
+              cursor: isDeleting ? "not-allowed" : "pointer",
+              opacity: isDeleting ? 0.7 : 1,
+            }}
+          >
+            {isDeleting ? "삭제 중..." : "삭제하기"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/notes/components/DeletionSuccessModal.tsx
+++ b/src/features/notes/components/DeletionSuccessModal.tsx
@@ -1,0 +1,124 @@
+interface DeletionSuccessModalProps {
+  onClose: () => void;
+}
+
+export const DeletionSuccessModal = ({
+  onClose,
+}: DeletionSuccessModalProps) => {
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[#00000033]"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="relative bg-white"
+        style={{
+          width: "560px",
+          height: "360px",
+          borderRadius: "20px",
+          boxShadow: "0px 10px 40px rgba(0, 0, 0, 0.1)",
+        }}
+      >
+        {/* Check Icon */}
+        <div
+          className="absolute inset-x-0 mx-auto"
+          style={{
+            top: "40px",
+            width: "80px",
+            height: "80px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: "50%",
+            background: "#E8EFFF",
+          }}
+        >
+          <svg
+            width="40"
+            height="40"
+            viewBox="0 0 40 40"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 20L16 26L30 12"
+              stroke="#2A6AFF"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+
+        {/* Title Section */}
+        <div
+          className="absolute inset-x-0 mx-auto flex flex-col items-center"
+          style={{ top: "153px", width: "319px" }}
+        >
+          <h2
+            style={{
+              color: "#000",
+              textAlign: "center",
+              fontFamily: "Pretendard",
+              fontSize: "32px",
+              fontStyle: "normal",
+              fontWeight: 600,
+              lineHeight: "48px",
+              letterSpacing: "-0.006px",
+            }}
+          >
+            노트가 삭제되었습니다.
+          </h2>
+
+          <p
+            style={{
+              color: "#00000066",
+              textAlign: "center",
+              fontFamily: "Pretendard",
+              fontSize: "18px",
+              fontStyle: "normal",
+              fontWeight: 400,
+              lineHeight: "28px",
+              letterSpacing: "-0.002px",
+              width: "319px",
+              marginTop: "16px",
+            }}
+          >
+            선택하신 노트들이 영구적으로 삭제되었습니다.
+          </p>
+        </div>
+
+        {/* Button Section */}
+        <button
+          onClick={onClose}
+          className="absolute inset-x-0 bottom-[19px] mx-auto"
+          style={{
+            display: "flex",
+            width: "492px",
+            height: "56px",
+            padding: "10px",
+            justifyContent: "center",
+            alignItems: "center",
+            gap: "10px",
+            borderRadius: "20px",
+            background: "#2A6AFF",
+            border: "none",
+            color: "#FFF",
+            fontFamily: "Pretendard",
+            fontSize: "18px",
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/notes/hooks/useNotes.ts
+++ b/src/features/notes/hooks/useNotes.ts
@@ -9,6 +9,7 @@ import {
   createNote,
   getNoteDetail,
   deleteNotesBulk,
+  deleteNote,
 } from "../api/notes_api";
 import type {
   NoteListParams,
@@ -104,6 +105,19 @@ export const useDeleteNotesBulk = () => {
 
   return useMutation({
     mutationFn: (noteIds: number[]) => deleteNotesBulk(noteIds),
+    onSuccess: () => {
+      // 노트 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+    },
+  });
+};
+
+// 단일 노트 삭제 Hook
+export const useDeleteNote = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (noteId: number) => deleteNote(noteId),
     onSuccess: () => {
       // 노트 목록 캐시 무효화
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });

--- a/src/features/notes/hooks/useNotes.ts
+++ b/src/features/notes/hooks/useNotes.ts
@@ -4,7 +4,12 @@ import {
   useQueryClient,
   useInfiniteQuery,
 } from "@tanstack/react-query";
-import { getNoteList, createNote, getNoteDetail } from "../api/notes_api";
+import {
+  getNoteList,
+  createNote,
+  getNoteDetail,
+  deleteNotesBulk,
+} from "../api/notes_api";
 import type {
   NoteListParams,
   CreateNoteRequest,
@@ -90,5 +95,18 @@ export const useNoteDetail = (
     },
     enabled: (options?.enabled ?? true) && !!noteId,
     staleTime: 1000 * 60 * 1, // 1분
+  });
+};
+
+// 노트 벌크 삭제 Hook
+export const useDeleteNotesBulk = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (noteIds: number[]) => deleteNotesBulk(noteIds),
+    onSuccess: () => {
+      // 노트 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+    },
   });
 };

--- a/src/features/notes/pages/NotesPage.tsx
+++ b/src/features/notes/pages/NotesPage.tsx
@@ -19,6 +19,8 @@ import { DropdownIcon } from "../../../shared/components/icons/ChatInputIcons";
 
 // 컴포넌트
 import { LoadingSpinner } from "../../../shared/components/loading-spinner";
+import { DeleteNotesModal } from "../components/DeleteNotesModal";
+import { DeletionSuccessModal } from "../components/DeletionSuccessModal";
 
 const ArrowLeftIcon = () => (
   <svg
@@ -68,6 +70,10 @@ export const NotesPage = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [sortOrder, setSortOrder] = useState<SortOrder>("lastUsedAt,desc");
   const [isSortDropdownOpen, setIsSortDropdownOpen] = useState(false);
+  const [isSelectMode, setIsSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
 
   // API 데이터 조회
   const { data, isLoading, isError } = useNoteList({
@@ -83,6 +89,29 @@ export const NotesPage = () => {
     setSortOrder(value);
     setCurrentPage(0); // 정렬 변경 시 첫 페이지로 리셋
     setIsSortDropdownOpen(false);
+  };
+
+  const toggleSelectMode = () => {
+    setIsSelectMode((prev) => !prev);
+    setSelectedIds([]);
+  };
+
+  const toggleIdSelection = (id: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((selectedId) => selectedId !== id)
+        : [...prev, id],
+    );
+  };
+
+  const handleActionClick = () => {
+    if (isSelectMode) {
+      if (selectedIds.length > 0) {
+        setIsDeleteModalOpen(true);
+      }
+    } else {
+      toggleSelectMode();
+    }
   };
 
   const handlePreviousPage = () => {
@@ -125,48 +154,67 @@ export const NotesPage = () => {
               </h1>
             </div>
 
-            {/* 정렬 버튼 + 노트 개수(같은 가로선) */}
+            {/* 정렬 버튼 + 선택 버튼 + 노트 개수(같은 가로선) */}
             <div className="w-full">
               <div className="flex items-center justify-between">
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setIsSortDropdownOpen((prevIsOpen) => !prevIsOpen)
-                    }
-                    className="flex h-[28px] w-[140px] items-center justify-between overflow-hidden rounded-[8px] border-[0.5px] border-[#D1D6DE] bg-white px-[12px] py-[10px] transition-colors hover:bg-gray-50"
-                  >
-                    <span className="font-['Noto_Sans_KR',sans-serif] text-[14px] leading-[15px] font-normal whitespace-nowrap text-[#2F3440]">
-                      {SORT_OPTIONS.find((option) => option.value === sortOrder)
-                        ?.label ?? "정렬"}
-                    </span>
-                    <span className="h-[16px] w-[16px] shrink-0">
-                      <DropdownIcon
-                        className={`h-full w-full text-[#2F3440] transition-transform ${
-                          isSortDropdownOpen ? "rotate-180" : ""
-                        }`}
-                      />
-                    </span>
-                  </button>
-
-                  {isSortDropdownOpen && (
-                    <div className="absolute right-0 z-10 mt-[4px] w-[192px] rounded-[8px] border border-[#D1D6DE] bg-white py-[4px] shadow-[0_8px_20px_rgba(0,0,0,0.08)]">
-                      {SORT_OPTIONS.map((option) => (
-                        <button
-                          key={option.value}
-                          type="button"
-                          onClick={() => handleSelectSort(option.value)}
-                          className={`mx-[4px] flex w-[calc(100%-8px)] items-center rounded-[8px] px-[12px] py-[8px] text-left text-[13px] leading-[18px] transition-shadow ${
-                            sortOrder === option.value
-                              ? "border border-[#2A6AFF] font-medium text-[#003880]"
-                              : "text-[#2F3440] hover:shadow-[0_0_0_3px_rgba(42,106,255,0.15)]"
+                <div className="flex items-center gap-[8px]">
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setIsSortDropdownOpen((prevIsOpen) => !prevIsOpen)
+                      }
+                      className="flex h-[28px] w-[140px] items-center justify-between overflow-hidden rounded-[8px] border-[0.5px] border-[#D1D6DE] bg-white px-[12px] py-[10px] transition-colors hover:bg-gray-50"
+                    >
+                      <span className="font-['Noto_Sans_KR',sans-serif] text-[14px] leading-[15px] font-normal whitespace-nowrap text-[#2F3440]">
+                        {SORT_OPTIONS.find(
+                          (option) => option.value === sortOrder,
+                        )?.label ?? "정렬"}
+                      </span>
+                      <span className="h-[16px] w-[16px] shrink-0">
+                        <DropdownIcon
+                          className={`h-full w-full text-[#2F3440] transition-transform ${
+                            isSortDropdownOpen ? "rotate-180" : ""
                           }`}
-                        >
-                          {option.label}
-                        </button>
-                      ))}
-                    </div>
-                  )}
+                        />
+                      </span>
+                    </button>
+
+                    {isSortDropdownOpen && (
+                      <div className="absolute right-0 z-10 mt-[4px] w-[192px] rounded-[8px] border border-[#D1D6DE] bg-white py-[4px] shadow-[0_8px_20px_rgba(0,0,0,0.08)]">
+                        {SORT_OPTIONS.map((option) => (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => handleSelectSort(option.value)}
+                            className={`mx-[4px] flex w-[calc(100%-8px)] items-center rounded-[8px] px-[12px] py-[8px] text-left text-[13px] leading-[18px] transition-shadow ${
+                              sortOrder === option.value
+                                ? "border border-[#2A6AFF] font-medium text-[#003880]"
+                                : "text-[#2F3440] hover:shadow-[0_0_0_3px_rgba(42,106,255,0.15)]"
+                            }`}
+                          >
+                            {option.label}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* 선택 버튼 */}
+                  <button
+                    onClick={handleActionClick}
+                    className={`flex items-center justify-center rounded-xl border-[0.5px] border-[#D1D6DE] bg-white font-['Pretendard'] text-[14px] font-medium transition-all hover:border-[#2A6AFF] hover:bg-[#2A6AFF] hover:text-white ${
+                      isSelectMode
+                        ? "border-[#2A6AFF] text-[#2A6AFF]"
+                        : "text-[#9CA4B0]"
+                    }`}
+                    style={{
+                      width: "80px",
+                      height: "32px",
+                    }}
+                  >
+                    {isSelectMode ? "삭제하기" : "선택"}
+                  </button>
                 </div>
 
                 <div className="flex items-center gap-[8px]">
@@ -212,56 +260,140 @@ export const NotesPage = () => {
                     <LoadingSpinner size={80} />
                   </div>
                 ) : notes.length > 0 ? (
-                  notes.map((note) => (
-                    <Link
-                      key={note.noteId}
-                      to={`/app/chat/${note.noteId}`}
-                      className="group flex h-[229px] w-[271px] flex-col rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] transition-colors hover:bg-[#E8ECF1]"
-                    >
-                      {/* 상단 썸네일 영역 (149px 높이) */}
-                      <div className="h-[149px] w-full overflow-hidden rounded-t-[12px] bg-[#E8ECF1]">
-                        {note.thumbnailUrl ? (
-                          <img
-                            src={note.thumbnailUrl}
-                            alt={note.title}
-                            loading="lazy"
-                            decoding="async"
-                            width={271}
-                            height={149}
-                            className="h-full w-full object-cover"
-                          />
-                        ) : (
-                          <div className="flex h-full w-full items-center justify-center bg-[#F1F4F8]" />
-                        )}
-                      </div>
+                  notes.map((note) => {
+                    const isSelected = selectedIds.includes(note.noteId);
+                    return isSelectMode ? (
+                      <button
+                        key={note.noteId}
+                        onClick={() => toggleIdSelection(note.noteId)}
+                        className={`group relative flex h-[229px] w-[271px] flex-col rounded-[12px] text-left transition-colors ${
+                          isSelected
+                            ? "border-[1.5px] border-[#2A6AFF] bg-[#F1F4F8]"
+                            : "border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] hover:bg-[#E8ECF1]"
+                        }`}
+                        type="button"
+                      >
+                        {/* 체크박스 */}
+                        <div
+                          className={`absolute top-[12px] right-[12px] z-30 flex h-[20px] w-[20px] items-center justify-center rounded-[4px] border-[1.5px] transition-colors ${
+                            isSelected
+                              ? "border-[#2A6AFF] bg-[#2A6AFF]"
+                              : "border-[#D1D6DE] bg-white"
+                          }`}
+                        >
+                          {isSelected && (
+                            <svg
+                              width="14"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              fill="none"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11.5 3.5L5.25 10.5L2.5 7.5"
+                                stroke="#FFFFFF"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          )}
+                        </div>
 
-                      {/* 하단 흰색 정보 영역 (80px 높이) */}
-                      <div className="flex h-[80px] w-full flex-col items-start justify-center rounded-b-[12px] border-t-[0.5px] border-[#D1D6DE] bg-white px-[16px] py-[8px]">
-                        <div className="flex w-full flex-col gap-[8px]">
-                          {/* 제목 */}
-                          <h3 className="line-clamp-1 text-[14px] leading-[20px] font-medium text-black">
-                            {note.title}
-                          </h3>
+                        {/* 상단 썸네일 영역 (149px 높이) */}
+                        <div className="h-[149px] w-full overflow-hidden rounded-t-[12px] bg-[#E8ECF1]">
+                          {note.thumbnailUrl ? (
+                            <img
+                              src={note.thumbnailUrl}
+                              alt={note.title}
+                              loading="lazy"
+                              decoding="async"
+                              width={271}
+                              height={149}
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-[#F1F4F8]" />
+                          )}
+                        </div>
 
-                          {/* 메타데이터 */}
-                          <div className="flex flex-col items-start gap-0 text-[11px] leading-[18px] font-normal text-[#6D6D6D]">
-                            <p>
-                              생성:{" "}
-                              {new Date(note.createdAt).toLocaleDateString(
-                                "ko-KR",
-                              )}
-                            </p>
-                            <p>
-                              최근 사용:{" "}
-                              {new Date(note.lastUsedAt).toLocaleDateString(
-                                "ko-KR",
-                              )}
-                            </p>
+                        {/* 하단 흰색 정보 영역 (80px 높이) */}
+                        <div className="flex h-[80px] w-full flex-col items-start justify-center rounded-b-[12px] border-t-[0.5px] border-[#D1D6DE] bg-white px-[16px] py-[8px]">
+                          <div className="flex w-full flex-col gap-[8px]">
+                            {/* 제목 */}
+                            <h3 className="line-clamp-1 text-[14px] leading-[20px] font-medium text-black">
+                              {note.title}
+                            </h3>
+
+                            {/* 메타데이터 */}
+                            <div className="flex flex-col items-start gap-0 text-[11px] leading-[18px] font-normal text-[#6D6D6D]">
+                              <p>
+                                생성:{" "}
+                                {new Date(note.createdAt).toLocaleDateString(
+                                  "ko-KR",
+                                )}
+                              </p>
+                              <p>
+                                최근 사용:{" "}
+                                {new Date(note.lastUsedAt).toLocaleDateString(
+                                  "ko-KR",
+                                )}
+                              </p>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </Link>
-                  ))
+                      </button>
+                    ) : (
+                      <Link
+                        key={note.noteId}
+                        to={`/app/chat/${note.noteId}`}
+                        className="group flex h-[229px] w-[271px] flex-col rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] transition-colors hover:bg-[#E8ECF1]"
+                      >
+                        {/* 상단 썸네일 영역 (149px 높이) */}
+                        <div className="h-[149px] w-full overflow-hidden rounded-t-[12px] bg-[#E8ECF1]">
+                          {note.thumbnailUrl ? (
+                            <img
+                              src={note.thumbnailUrl}
+                              alt={note.title}
+                              loading="lazy"
+                              decoding="async"
+                              width={271}
+                              height={149}
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-[#F1F4F8]" />
+                          )}
+                        </div>
+
+                        {/* 하단 흰색 정보 영역 (80px 높이) */}
+                        <div className="flex h-[80px] w-full flex-col items-start justify-center rounded-b-[12px] border-t-[0.5px] border-[#D1D6DE] bg-white px-[16px] py-[8px]">
+                          <div className="flex w-full flex-col gap-[8px]">
+                            {/* 제목 */}
+                            <h3 className="line-clamp-1 text-[14px] leading-[20px] font-medium text-black">
+                              {note.title}
+                            </h3>
+
+                            {/* 메타데이터 */}
+                            <div className="flex flex-col items-start gap-0 text-[11px] leading-[18px] font-normal text-[#6D6D6D]">
+                              <p>
+                                생성:{" "}
+                                {new Date(note.createdAt).toLocaleDateString(
+                                  "ko-KR",
+                                )}
+                              </p>
+                              <p>
+                                최근 사용:{" "}
+                                {new Date(note.lastUsedAt).toLocaleDateString(
+                                  "ko-KR",
+                                )}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      </Link>
+                    );
+                  })
                 ) : (
                   <div className="col-span-full flex items-center justify-center py-[40px]">
                     <span className="text-[14px] leading-[20px] text-[#6D6D6D]">
@@ -368,6 +500,21 @@ export const NotesPage = () => {
           )}
         </div>
       </div>
+      {isDeleteModalOpen && (
+        <DeleteNotesModal
+          selectedIds={selectedIds}
+          onClose={() => setIsDeleteModalOpen(false)}
+          onSuccess={() => {
+            setIsDeleteModalOpen(false);
+            setIsSuccessModalOpen(true);
+            setIsSelectMode(false);
+            setSelectedIds([]);
+          }}
+        />
+      )}
+      {isSuccessModalOpen && (
+        <DeletionSuccessModal onClose={() => setIsSuccessModalOpen(false)} />
+      )}
     </div>
   );
 };

--- a/src/mocks/handlers/notes.ts
+++ b/src/mocks/handlers/notes.ts
@@ -316,4 +316,48 @@ export const notesHandlers = [
       result: response,
     });
   }),
+
+  // 노트 벌크 삭제
+  http.delete(`${BASE_URL}/api/notes`, async ({ request }) => {
+    await delay(500);
+
+    const body = await request.json();
+    const noteIds = body.noteIds as number[];
+
+    console.log("[MSW] 노트 벌크 삭제:", noteIds);
+
+    if (!Array.isArray(noteIds) || noteIds.length === 0) {
+      return HttpResponse.json(
+        {
+          isSuccess: false,
+          code: "NOTE4000",
+          message: "삭제할 노트 ID가 없습니다.",
+          result: null,
+        },
+        { status: 400 },
+      );
+    }
+
+    // mockNotes에서 해당 ID의 노트 제거
+    const deletedNoteIds = noteIds.filter((id) => {
+      const index = mockNotes.findIndex((n) => n.noteId === id);
+      if (index > -1) {
+        mockNotes.splice(index, 1);
+        return true;
+      }
+      return false;
+    });
+
+    return HttpResponse.json<
+      ApiResponse<{ deletedCount: number; deletedNoteIds: number[] }>
+    >({
+      isSuccess: true,
+      code: "NOTE2020",
+      message: "노트 삭제 성공",
+      result: {
+        deletedCount: deletedNoteIds.length,
+        deletedNoteIds,
+      },
+    });
+  }),
 ];

--- a/src/mocks/handlers/notes.ts
+++ b/src/mocks/handlers/notes.ts
@@ -360,4 +360,57 @@ export const notesHandlers = [
       },
     });
   }),
+
+  // 단일 노트 삭제
+  http.delete(`${BASE_URL}/api/notes/:noteId`, async ({ params }) => {
+    await delay(500);
+
+    const noteId = Number(params.noteId);
+
+    console.log("[MSW] 노트 단일 삭제:", noteId);
+
+    // 해당 noteId의 노트 찾기
+    const noteIndex = mockNotes.findIndex((n) => n.noteId === noteId);
+
+    if (noteIndex === -1) {
+      return HttpResponse.json(
+        {
+          isSuccess: false,
+          code: "NOTE4041",
+          message: "노트를 찾을 수 없습니다.",
+          result: null,
+        },
+        { status: 404 },
+      );
+    }
+
+    const note = mockNotes[noteIndex];
+    const assetCount = mockNoteAssets[noteId]?.length ?? 0;
+    const conversationCount = note.conversationCount;
+
+    // Mock 저장소 해제 (자산 크기 기반)
+    const freedStorageBytes = assetCount * 1048576; // 각 자산당 1MB 가정
+
+    // mockNotes에서 해당 노트 삭제
+    mockNotes.splice(noteIndex, 1);
+
+    return HttpResponse.json<
+      ApiResponse<{
+        deletedNoteId: number;
+        deletedConversationCount: number;
+        deletedAssetCount: number;
+        freedStorageBytes: number;
+      }>
+    >({
+      isSuccess: true,
+      code: "NOTE2020",
+      message: "노트 및 관련 대화, 자산 데이터가 모두 삭제되었습니다.",
+      result: {
+        deletedNoteId: noteId,
+        deletedConversationCount: conversationCount,
+        deletedAssetCount: assetCount,
+        freedStorageBytes,
+      },
+    });
+  }),
 ];


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #이슈번호

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 저장소의 선택버튼과 같은 로직의 노트 선택버튼 생성
- 노트 삭제 api 연동

## 📸 스크린샷

노트 삭제 버튼 구현
<img width="1054" height="769" alt="image" src="https://github.com/user-attachments/assets/a1e58af6-ac70-4418-9fee-61447c419e8e" />

노트 삭제 api 연동 테스트
<img width="1861" height="845" alt="image" src="https://github.com/user-attachments/assets/cf9b55a9-9e1c-4676-a89f-3e144057cb09" />


## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 노트 목록에 다중 선택 모드 추가 — '선택/삭제하기' 버튼으로 전환하고 선택한 항목을 시각적으로 강조하여 복수 선택 가능
  * 한 번에 여러 노트를 삭제하는 대량 삭제 기능 추가로 빠른 정리 가능
  * 삭제 전 확인 모달과 삭제 완료 확인 모달을 추가해 삭제 과정이 명확하고 안전하게 이루어짐
<!-- end of auto-generated comment: release notes by coderabbit.ai -->