### PR TITLE
Feat(#125): 저장소 페이지 자산 썸네일 보이도록 구현 및 용량 게이지바 수정

### DIFF
--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useState } from "react";
+import * as pdfjsLib from "pdfjs-dist";
+import type { RenderTask, PDFDocumentProxy } from "pdfjs-dist";
+import pdfjsWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+import { LoadingSpinner } from "@/shared/components/loading-spinner";
+
+// Worker 설정 (로컬 번들 사용)
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
+
+interface FileRendererProps {
+  fileUrl: string | null;
+  fileType: "pdf" | "image" | null;
+  fileName: string;
+}
+
+export const FileRenderer = ({
+  fileUrl,
+  fileType,
+  fileName,
+}: FileRendererProps) => {
+  const [pageNumber, setPageNumber] = useState(1);
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [scale] = useState(1.0);
+  const [error, setError] = useState<string | null>(null);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const renderTaskRef = useRef<RenderTask | null>(null);
+  const pdfRef = useRef<PDFDocumentProxy | null>(null);
+
+  // 1. PDF 문서 로드
+  useEffect(() => {
+    if (!fileUrl || fileType !== "pdf") {
+      pdfRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+    const loadingTask = pdfjsLib.getDocument(fileUrl);
+
+    loadingTask.promise
+      .then((pdf) => {
+        if (cancelled) {
+          pdf.destroy();
+          return;
+        }
+        pdfRef.current = pdf;
+        setNumPages(pdf.numPages);
+        setPageNumber(1); // 파일 변경 시 페이지 초기화
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("PDF 로드 오류:", err);
+          setError("PDF를 불러오는 중 오류가 발생했습니다.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      loadingTask.destroy();
+      pdfRef.current = null;
+    };
+  }, [fileUrl, fileType]);
+
+  // 2. PDF 페이지 렌더링
+  useEffect(() => {
+    const pdf = pdfRef.current;
+    if (!pdf || fileType !== "pdf") return;
+
+    let cancelled = false;
+
+    const renderPage = async () => {
+      try {
+        if (renderTaskRef.current) {
+          renderTaskRef.current.cancel();
+        }
+
+        const page = await pdf.getPage(pageNumber);
+        if (cancelled) return;
+
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        const viewport = page.getViewport({ scale });
+        canvas.height = viewport.height;
+        canvas.width = viewport.width;
+
+        const renderTask = page.render({
+          canvas: canvas,
+          canvasContext: canvas.getContext("2d")!,
+          viewport: viewport,
+        });
+        renderTaskRef.current = renderTask;
+
+        await renderTask.promise;
+      } catch (err: unknown) {
+        const renderErr = err as { name?: string };
+        if (renderErr.name !== "RenderingCancelledException" && !cancelled) {
+          console.error("PDF 렌더링 오류:", err);
+          setError("PDF를 불러오는 중 오류가 발생했습니다.");
+        }
+      }
+    };
+
+    renderPage();
+
+    return () => {
+      cancelled = true;
+      if (renderTaskRef.current) {
+        renderTaskRef.current.cancel();
+      }
+    };
+  }, [pageNumber, scale, fileType, numPages]); // fileType 의존성 추가 (이미지 -> PDF 전환 시 필요)
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center text-red-500">
+        <p>{error}</p>
+        <button
+          onClick={() => window.location.reload()}
+          className="mt-2 text-sm underline"
+        >
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  if (fileType === "image" && fileUrl) {
+    return (
+      <div className="flex h-full flex-col bg-gray-100">
+        {/* 네비게이션 바 (이미지용 - 페이지 컨트롤 없음) */}
+        <div className="flex shrink-0 items-center justify-between border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
+          <span className="truncate text-sm font-medium text-gray-700">
+            {fileName}
+          </span>
+        </div>
+
+        <div className="flex min-h-0 flex-1 items-start justify-center overflow-auto bg-gray-50 p-4 pt-6">
+          <img
+            src={fileUrl}
+            alt={fileName}
+            className="h-full w-full object-contain"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (fileType === "pdf") {
+    return (
+      <div className="flex h-full flex-col bg-gray-100">
+        {/* 네비게이션 바 */}
+        <div className="flex shrink-0 items-center justify-between border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
+          <span className="truncate text-sm font-medium text-gray-700">
+            {fileName} (PDF)
+          </span>
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <button
+              onClick={() => setPageNumber((prev) => Math.max(prev - 1, 1))}
+              disabled={pageNumber <= 1}
+              className="rounded p-1 hover:bg-gray-100 disabled:opacity-30"
+            >
+              {"<"}
+            </button>
+            <span>
+              {pageNumber} / {numPages || "-"}
+            </span>
+            <button
+              onClick={() =>
+                setPageNumber((prev) => Math.min(prev + 1, numPages || prev))
+              }
+              disabled={!numPages || pageNumber >= numPages}
+              className="rounded p-1 hover:bg-gray-100 disabled:opacity-30"
+            >
+              {">"}
+            </button>
+          </div>
+        </div>
+
+        {/* 캔버스 영역 */}
+        <div className="flex min-h-0 flex-1 items-start justify-center overflow-auto bg-gray-50 p-4 pt-6">
+          <div className="shadow-lg">
+            <canvas
+              ref={canvasRef}
+              className="block bg-white"
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center">
+      <LoadingSpinner size={40} />
+    </div>
+  );
+};

--- a/src/features/chat/components/leftpanel/StorageContent.tsx
+++ b/src/features/chat/components/leftpanel/StorageContent.tsx
@@ -9,6 +9,7 @@ import { deleteAssets } from "@/features/assets/api/assetApi";
 import { useNoteDetail, noteKeys } from "@/features/notes/hooks/useNotes";
 import type { PanelTab } from "./types";
 import { useAuthStore } from "@/features/auth/store/auth_store";
+import { useStorageStore } from "@/features/storage/store/useStorageStore";
 import {
   PLAN_DETAILS,
   type PlanType,
@@ -147,6 +148,8 @@ export const StorageContent = ({
     }
   };
 
+  /* user duplicated declaration removed */
+  const { setViewerFileId } = useStorageStore();
   const [, setSearchParams] = useSearchParams();
 
   const handleOpenViewer = () => {
@@ -156,6 +159,7 @@ export const StorageContent = ({
     }
 
     const targetFileId = selectedIds[0];
+    setViewerFileId(targetFileId);
 
     setSearchParams((prev) => {
       prev.set("panel", "viewer");
@@ -170,6 +174,7 @@ export const StorageContent = ({
 
   const handleFileClick = (fileId: number) => {
     if (isSelectMode) return;
+    setViewerFileId(fileId);
     setSearchParams((prev) => {
       prev.set("panel", "viewer");
       prev.set("file", fileId.toString());

--- a/src/features/chat/components/leftpanel/ViewerContent.tsx
+++ b/src/features/chat/components/leftpanel/ViewerContent.tsx
@@ -11,6 +11,7 @@ import { LoadingSpinner } from "@/shared/components/loading-spinner";
 import { FILE_ACCEPT } from "@/features/assets/utils/fileValidation";
 
 import { useAuthStore } from "@/features/auth/store/auth_store";
+import { useStorageStore } from "@/features/storage/store/useStorageStore";
 import {
   PLAN_DETAILS,
   type PlanType,
@@ -44,6 +45,41 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
   const [error, setError] = useState<string | null>(null);
   const [, setSearchParams] = useSearchParams();
   const { user } = useAuthStore();
+  const { viewerFileId, setViewerFileId } = useStorageStore();
+
+  // URL의 fileId가 있으면 스토어 업데이트 (딥링크 지원)
+  useEffect(() => {
+    if (fileId) {
+      const parsedId = parseInt(fileId, 10);
+      if (!isNaN(parsedId) && parsedId !== viewerFileId) {
+        setViewerFileId(parsedId);
+      }
+    }
+  }, [fileId, setViewerFileId, viewerFileId]);
+
+  // 실제 사용할 ID 결정 (스토어 우선, 없으면 props)
+  // props는 초기 로드 시 딥링크 처리를 위해 필요하지만, 이후엔 스토어 값이 우선됨
+  const activeFileId = viewerFileId || (fileId ? parseInt(fileId, 10) : null);
+
+  // ESC 키 핸들러: 파일 닫기 (스토어 + URL 초기화)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setViewerFileId(null); // 스토어 초기화
+        setSearchParams(
+          (prev) => {
+            prev.delete("panel");
+            prev.delete("file");
+            return prev;
+          },
+          { replace: true },
+        );
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [setSearchParams, setViewerFileId]);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const renderTaskRef = useRef<RenderTask | null>(null);
@@ -88,6 +124,7 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
 
         // 업로드 성공 시 해당 파일로 즉시 이동
         if (result?.assetId) {
+          setViewerFileId(result.assetId); // 스토어 업데이트
           setSearchParams((prev) => {
             prev.set("panel", "viewer");
             prev.set("file", result.assetId.toString());
@@ -108,7 +145,7 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
     let cancelled = false;
 
     const fetchUrlData = async () => {
-      if (!fileId) return;
+      if (!activeFileId) return;
 
       setIsLoading(true);
       setError(null);
@@ -119,12 +156,7 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
       setNumPages(null);
 
       try {
-        const numericId = parseInt(fileId, 10);
-        if (isNaN(numericId)) {
-          throw new Error("유효하지 않은 파일 ID입니다.");
-        }
-
-        const response = await getDownloadUrl(numericId);
+        const response = await getDownloadUrl(activeFileId);
         if (cancelled) return;
         const { downloadUrl, fileName: fetchedFileName } = response.result;
 
@@ -161,7 +193,7 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
     return () => {
       cancelled = true;
     };
-  }, [fileId]);
+  }, [activeFileId]);
 
   // 2. PDF 문서 로드 (pdfUrl 변경 시에만)
   useEffect(() => {
@@ -246,7 +278,7 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
     };
   }, [pageNumber, scale, fileType, numPages]);
 
-  if (!fileId) {
+  if (!activeFileId) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2">
         {/* hidden input for file upload */}
@@ -280,7 +312,7 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
       {/* 파일 정보 및 네비게이션 바 */}
       <div className="flex shrink-0 items-center justify-between border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
         <span className="truncate text-sm font-medium text-gray-700">
-          {fileName || `파일 ${fileId}`}
+          {fileName || `파일 ${activeFileId}`}
         </span>
         {fileType === "pdf" && (
           <div className="flex items-center gap-2 text-sm text-gray-500">

--- a/src/features/chat/components/leftpanel/ViewerContent.tsx
+++ b/src/features/chat/components/leftpanel/ViewerContent.tsx
@@ -1,33 +1,9 @@
-import { useEffect, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
-import * as pdfjsLib from "pdfjs-dist";
-import type { RenderTask, PDFDocumentProxy } from "pdfjs-dist";
-import pdfjsWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
-import { useFileUpload } from "@/shared/hooks/useFileUpload";
-import { PdfIcon } from "@/shared/components/icons/HomepageInputIcons";
+import { useEffect, useState } from "react";
 import { getDownloadUrl } from "@/features/assets/api/assetApi";
-import { useAssetUpload } from "@/features/assets/hooks/useAssetUpload";
 import { LoadingSpinner } from "@/shared/components/loading-spinner";
-import { FILE_ACCEPT } from "@/features/assets/utils/fileValidation";
-
-import { useAuthStore } from "@/features/auth/store/auth_store";
-import { useStorageStore } from "@/features/storage/store/useStorageStore";
-import {
-  PLAN_DETAILS,
-  type PlanType,
-} from "@/features/subscription/types/plan_types";
-
-// Worker 설정 (로컬 번들 사용)
-pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
-
-const parseSize = (sizeStr: string) => {
-  const value = parseInt(sizeStr.replace(/\D/g, ""), 10);
-  const unit = sizeStr.replace(/[^A-Za-z]/g, "").toUpperCase();
-  if (unit.includes("GB")) return value * 1024 * 1024 * 1024;
-  if (unit.includes("MB")) return value * 1024 * 1024;
-  if (unit.includes("KB")) return value * 1024;
-  return value;
-};
+import { useViewerSync } from "@/features/chat/hooks/useViewerSync";
+import { ViewerEmpty } from "./ViewerEmpty";
+import { FileRenderer } from "./FileRenderer";
 
 interface ViewerContentProps {
   noteId: string;
@@ -35,112 +11,16 @@ interface ViewerContentProps {
 }
 
 export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
+  // 1. 상태 동기화 및 전역 이벤트 핸들링 (커스텀 훅)
+  const { activeFileId } = useViewerSync(fileId);
+
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [fileType, setFileType] = useState<"pdf" | "image" | null>(null);
   const [fileName, setFileName] = useState<string>("");
-  const [pageNumber, setPageNumber] = useState(1);
-  const [numPages, setNumPages] = useState<number | null>(null);
-  const [scale] = useState(1.0);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [, setSearchParams] = useSearchParams();
-  const { user } = useAuthStore();
-  const { viewerFileId, setViewerFileId } = useStorageStore();
 
-  // URL의 fileId가 있으면 스토어 업데이트 (딥링크 지원)
-  useEffect(() => {
-    if (fileId) {
-      const parsedId = parseInt(fileId, 10);
-      if (!isNaN(parsedId) && parsedId !== viewerFileId) {
-        setViewerFileId(parsedId);
-      }
-    }
-  }, [fileId, setViewerFileId, viewerFileId]);
-
-  // 실제 사용할 ID 결정 (스토어 우선, 없으면 props)
-  // props는 초기 로드 시 딥링크 처리를 위해 필요하지만, 이후엔 스토어 값이 우선됨
-  const activeFileId = viewerFileId || (fileId ? parseInt(fileId, 10) : null);
-
-  // ESC 키 핸들러: 파일 닫기 (스토어 + URL 초기화)
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setViewerFileId(null); // 스토어 초기화
-        setSearchParams(
-          (prev) => {
-            prev.delete("panel");
-            prev.delete("file");
-            return prev;
-          },
-          { replace: true },
-        );
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [setSearchParams, setViewerFileId]);
-
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const renderTaskRef = useRef<RenderTask | null>(null);
-  const pdfRef = useRef<PDFDocumentProxy | null>(null);
-
-  const { uploadAsset } = useAssetUpload();
-
-  // 파일 업로드 훅 사용
-  const { fileInputRef, openFileExplorer, handleFileChange } = useFileUpload(
-    async (file) => {
-      if (!file) return;
-
-      const isValidType =
-        file.type === "application/pdf" || file.type.startsWith("image/");
-
-      if (!isValidType) {
-        alert("PDF 또는 이미지 파일만 업로드 가능합니다.");
-        return;
-      }
-
-      const userPlan = (user?.plan as PlanType) || "Free";
-      const maxUploadSizeStr = PLAN_DETAILS[userPlan]?.maxUploadSize || "10MB";
-      const maxSizeBytes = parseSize(maxUploadSizeStr);
-
-      if (file.size > maxSizeBytes) {
-        alert(
-          `파일 크기가 너무 큽니다. ${userPlan} 플랜의 최대 업로드 크기는 ${maxUploadSizeStr}입니다.`,
-        );
-        return;
-      }
-
-      try {
-        setIsLoading(true);
-        const parsed = parseInt(noteId, 10);
-        if (!Number.isInteger(parsed) || parsed <= 0) {
-          setError("유효하지 않은 노트입니다. 노트를 다시 열어주세요.");
-          setIsLoading(false);
-          return;
-        }
-
-        const result = await uploadAsset(parsed, file);
-
-        // 업로드 성공 시 해당 파일로 즉시 이동
-        if (result?.assetId) {
-          setViewerFileId(result.assetId); // 스토어 업데이트
-          setSearchParams((prev) => {
-            prev.set("panel", "viewer");
-            prev.set("file", result.assetId.toString());
-            return prev;
-          });
-        }
-      } catch (err) {
-        console.error("파일 업로드 실패:", err);
-        setError("파일 업로드에 실패했습니다.");
-      } finally {
-        setIsLoading(false);
-      }
-    },
-  );
-
-  // 1. 파일 URL 가져오기
+  // 2. 파일 데이터 가져오기 (Controller Logic)
   useEffect(() => {
     let cancelled = false;
 
@@ -152,8 +32,6 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
       setPdfUrl(null);
       setFileType(null);
       setFileName("");
-      setPageNumber(1);
-      setNumPages(null);
 
       try {
         const response = await getDownloadUrl(activeFileId);
@@ -195,181 +73,41 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
     };
   }, [activeFileId]);
 
-  // 2. PDF 문서 로드 (pdfUrl 변경 시에만)
-  useEffect(() => {
-    if (!pdfUrl || fileType !== "pdf") {
-      pdfRef.current = null;
-      return;
-    }
-
-    let cancelled = false;
-    const loadingTask = pdfjsLib.getDocument(pdfUrl);
-
-    loadingTask.promise
-      .then((pdf) => {
-        if (cancelled) {
-          pdf.destroy();
-          return;
-        }
-        pdfRef.current = pdf;
-        setNumPages(pdf.numPages);
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          console.error("PDF 로드 오류:", err);
-          setError("PDF를 불러오는 중 오류가 발생했습니다.");
-        }
-      });
-
-    return () => {
-      cancelled = true;
-      loadingTask.destroy();
-      pdfRef.current = null;
-    };
-  }, [pdfUrl, fileType]);
-
-  // 3. PDF 페이지 렌더링 (페이지/스케일 변경 시)
-  useEffect(() => {
-    const pdf = pdfRef.current;
-    if (!pdf || fileType !== "pdf") return;
-
-    let cancelled = false;
-
-    const renderPage = async () => {
-      try {
-        if (renderTaskRef.current) {
-          renderTaskRef.current.cancel();
-        }
-
-        const page = await pdf.getPage(pageNumber);
-        if (cancelled) return;
-
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-
-        const viewport = page.getViewport({ scale });
-        canvas.height = viewport.height;
-        canvas.width = viewport.width;
-
-        const renderTask = page.render({
-          canvas: canvas,
-          canvasContext: canvas.getContext("2d")!,
-          viewport: viewport,
-        });
-        renderTaskRef.current = renderTask;
-
-        await renderTask.promise;
-      } catch (err: unknown) {
-        const renderErr = err as { name?: string };
-        if (renderErr.name !== "RenderingCancelledException" && !cancelled) {
-          console.error("PDF 렌더링 오류:", err);
-          setError("PDF를 불러오는 중 오류가 발생했습니다.");
-        }
-      }
-    };
-
-    renderPage();
-
-    return () => {
-      cancelled = true;
-      if (renderTaskRef.current) {
-        renderTaskRef.current.cancel();
-      }
-    };
-  }, [pageNumber, scale, fileType, numPages]);
-
+  // Case 1: 파일이 선택되지 않음 -> 업로드 UI (Empty State)
   if (!activeFileId) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center gap-2">
-        {/* hidden input for file upload */}
-        <input
-          type="file"
-          ref={fileInputRef}
-          className="hidden"
-          onChange={handleFileChange}
-          accept={FILE_ACCEPT}
-        />
+    return <ViewerEmpty noteId={noteId} />;
+  }
 
-        {/* 파일 업로드 버튼 */}
+  // Case 2: 로딩 중
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <LoadingSpinner size={40} />
+      </div>
+    );
+  }
+
+  // Case 3: 에러 발생
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center text-red-500">
+        <p>{error}</p>
         <button
-          onClick={openFileExplorer}
-          type="button"
-          className="group flex h-[160px] w-[220px] cursor-pointer flex-col items-center justify-center gap-[16px] rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white/40 px-[20px] py-[36px] shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-colors duration-700 hover:bg-[#2A6AFF33] active:bg-[#2A6AFF33]"
+          onClick={() => window.location.reload()}
+          className="mt-2 text-sm underline"
         >
-          <div>
-            <PdfIcon size={56} />
-          </div>
-          <p className="text-[18px] font-normal text-[#666666] transition-colors duration-700 group-hover:text-[#2542F0]">
-            뷰어로 파일 업로드
-          </p>
+          다시 시도
         </button>
       </div>
     );
   }
 
+  // Case 4: 파일 렌더링 (PDF / Image)
   return (
-    <div className="flex h-full flex-col bg-gray-100">
-      {/* 파일 정보 및 네비게이션 바 */}
-      <div className="flex shrink-0 items-center justify-between border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
-        <span className="truncate text-sm font-medium text-gray-700">
-          {fileName || `파일 ${activeFileId}`}
-        </span>
-        {fileType === "pdf" && (
-          <div className="flex items-center gap-2 text-sm text-gray-500">
-            <button
-              onClick={() => setPageNumber((prev) => Math.max(prev - 1, 1))}
-              disabled={pageNumber <= 1}
-              className="rounded p-1 hover:bg-gray-100 disabled:opacity-30"
-            >
-              {"<"}
-            </button>
-            <span>
-              {pageNumber} / {numPages || "-"}
-            </span>
-            <button
-              onClick={() =>
-                setPageNumber((prev) => Math.min(prev + 1, numPages || prev))
-              }
-              disabled={!numPages || pageNumber >= numPages}
-              className="rounded p-1 hover:bg-gray-100 disabled:opacity-30"
-            >
-              {">"}
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* 뷰어 영역 (PDF or Image) */}
-      <div className="flex min-h-0 flex-1 items-start justify-center overflow-auto bg-gray-50 p-4 pt-6">
-        {isLoading ? (
-          <div className="flex h-full items-center justify-center">
-            <LoadingSpinner size={40} />
-          </div>
-        ) : error ? (
-          <div className="flex h-full flex-col items-center justify-center text-red-500">
-            <p>{error}</p>
-            <button
-              onClick={() => window.location.reload()}
-              className="mt-2 text-sm underline"
-            >
-              다시 시도
-            </button>
-          </div>
-        ) : fileType === "image" && pdfUrl ? (
-          <img
-            src={pdfUrl}
-            alt={fileName}
-            className="h-full w-full object-contain"
-          />
-        ) : (
-          <div className="shadow-lg">
-            <canvas
-              ref={canvasRef}
-              className="block bg-white"
-            />
-          </div>
-        )}
-      </div>
-    </div>
+    <FileRenderer
+      fileUrl={pdfUrl}
+      fileType={fileType}
+      fileName={fileName}
+    />
   );
 };

--- a/src/features/chat/components/leftpanel/ViewerEmpty.tsx
+++ b/src/features/chat/components/leftpanel/ViewerEmpty.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useFileUpload } from "@/shared/hooks/useFileUpload";
+import { PdfIcon } from "@/shared/components/icons/HomepageInputIcons";
+import { useAssetUpload } from "@/features/assets/hooks/useAssetUpload";
+import { LoadingSpinner } from "@/shared/components/loading-spinner";
+import { FILE_ACCEPT } from "@/features/assets/utils/fileValidation";
+import { useAuthStore } from "@/features/auth/store/auth_store";
+import { useStorageStore } from "@/features/storage/store/useStorageStore";
+import {
+  PLAN_DETAILS,
+  type PlanType,
+} from "@/features/subscription/types/plan_types";
+
+interface ViewerEmptyProps {
+  noteId: string;
+}
+
+const parseSize = (sizeStr: string) => {
+  const value = parseInt(sizeStr.replace(/\D/g, ""), 10);
+  const unit = sizeStr.replace(/[^A-Za-z]/g, "").toUpperCase();
+  if (unit.includes("GB")) return value * 1024 * 1024 * 1024;
+  if (unit.includes("MB")) return value * 1024 * 1024;
+  if (unit.includes("KB")) return value * 1024;
+  return value;
+};
+
+export const ViewerEmpty = ({ noteId }: ViewerEmptyProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [, setSearchParams] = useSearchParams();
+  const { user } = useAuthStore();
+  const { setViewerFileId } = useStorageStore();
+  const { uploadAsset } = useAssetUpload();
+
+  const { fileInputRef, openFileExplorer, handleFileChange } = useFileUpload(
+    async (file) => {
+      if (!file) return;
+
+      const isValidType =
+        file.type === "application/pdf" || file.type.startsWith("image/");
+
+      if (!isValidType) {
+        alert("PDF 또는 이미지 파일만 업로드 가능합니다.");
+        return;
+      }
+
+      const userPlan = (user?.plan as PlanType) || "Free";
+      const maxUploadSizeStr = PLAN_DETAILS[userPlan]?.maxUploadSize || "10MB";
+      const maxSizeBytes = parseSize(maxUploadSizeStr);
+
+      if (file.size > maxSizeBytes) {
+        alert(
+          `파일 크기가 너무 큽니다. ${userPlan} 플랜의 최대 업로드 크기는 ${maxUploadSizeStr}입니다.`,
+        );
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        const parsed = parseInt(noteId, 10);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          setError("유효하지 않은 노트입니다. 노트를 다시 열어주세요.");
+          setIsLoading(false);
+          return;
+        }
+
+        const result = await uploadAsset(parsed, file);
+
+        if (result?.assetId) {
+          setViewerFileId(result.assetId);
+          setSearchParams((prev) => {
+            prev.set("panel", "viewer");
+            prev.set("file", result.assetId.toString());
+            return prev;
+          });
+        }
+      } catch (err) {
+        console.error("파일 업로드 실패:", err);
+        setError("파일 업로드에 실패했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <LoadingSpinner size={40} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center text-red-500">
+        <p>{error}</p>
+        <button
+          onClick={() => setError(null)}
+          className="mt-2 text-sm underline"
+        >
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2">
+      <input
+        type="file"
+        ref={fileInputRef}
+        className="hidden"
+        onChange={handleFileChange}
+        accept={FILE_ACCEPT}
+      />
+
+      <button
+        onClick={openFileExplorer}
+        type="button"
+        className="group flex h-[160px] w-[220px] cursor-pointer flex-col items-center justify-center gap-[16px] rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white/40 px-[20px] py-[36px] shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-colors duration-700 hover:bg-[#2A6AFF33] active:bg-[#2A6AFF33]"
+      >
+        <div>
+          <PdfIcon size={56} />
+        </div>
+        <p className="text-[18px] font-normal text-[#666666] transition-colors duration-700 group-hover:text-[#2542F0]">
+          뷰어로 파일 업로드
+        </p>
+      </button>
+    </div>
+  );
+};

--- a/src/features/chat/hooks/useViewerSync.ts
+++ b/src/features/chat/hooks/useViewerSync.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useStorageStore } from "@/features/storage/store/useStorageStore";
+
+/**
+ * 뷰어 상태 동기화 및 전역 이벤트 핸들링 훅
+ *
+ * 역할:
+ * 1. URL searchParams의 'file' 파라미터와 전역 스토어(viewerFileId) 동기화
+ * 2. ESC 키 입력 시 뷰어 닫기 (스토어 및 URL 초기화)
+ */
+export const useViewerSync = (urlFileId?: string) => {
+  const [, setSearchParams] = useSearchParams();
+  const { viewerFileId, setViewerFileId } = useStorageStore();
+
+  // 1. URL의 fileId가 있으면 스토어 업데이트 (딥링크/새로고침 지원)
+  useEffect(() => {
+    if (urlFileId) {
+      const parsedId = parseInt(urlFileId, 10);
+      if (!isNaN(parsedId) && parsedId !== viewerFileId) {
+        setViewerFileId(parsedId);
+      }
+    }
+  }, [urlFileId, setViewerFileId, viewerFileId]);
+
+  // 2. ESC 키 핸들러: 파일 닫기 (스토어 + URL 초기화)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setViewerFileId(null); // 스토어 초기화
+        setSearchParams(
+          (prev) => {
+            prev.delete("panel");
+            prev.delete("file");
+            return prev;
+          },
+          { replace: true },
+        );
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [setSearchParams, setViewerFileId]);
+
+  // 실제 사용할 ID 결정 (스토어 우선, 없으면 URL 파라미터 사용)
+  // URL 파라미터는 초기 로드 시 스토어가 비어있을 때 백업으로 사용됨
+  const activeFileId =
+    viewerFileId || (urlFileId ? parseInt(urlFileId, 10) : null);
+
+  return { activeFileId };
+};

--- a/src/features/sidebar/components/SidebarHeader.tsx
+++ b/src/features/sidebar/components/SidebarHeader.tsx
@@ -33,7 +33,7 @@ export const SidebarHeader = ({
             className="group rounded p-1 transition-colors"
           >
             <BarArrowIcon
-              className="mr-2 text-[#6B7280] transition-colors duration-500 group-hover:text-[#2A6AFF]"
+              className="mr-2 cursor-pointer text-[#6B7280] transition-colors duration-500 group-hover:text-[#2A6AFF]"
               size={26}
             />
           </button>

--- a/src/features/sidebar/components/SidebarProfile.tsx
+++ b/src/features/sidebar/components/SidebarProfile.tsx
@@ -53,7 +53,7 @@ export const SidebarProfile = ({
                 onUpgradeClick();
               }
             }}
-            className={`flex h-[24px] w-[88px] items-center justify-center rounded bg-[#2A6AFF] text-[14px] leading-none text-white transition-colors ${
+            className={`flex h-[24px] w-[88px] cursor-pointer items-center justify-center rounded bg-[#2A6AFF] text-[14px] leading-none text-white transition-colors ${
               authUser?.plan === "Pro"
                 ? "cursor-default opacity-50"
                 : "hover:bg-[#2A6AFF]/50 active:bg-white active:text-black"

--- a/src/features/storage/api/assets_api.ts
+++ b/src/features/storage/api/assets_api.ts
@@ -8,9 +8,11 @@ import type {
   DownloadUrlResponse,
   BulkDeleteRequest,
   BulkDeleteResponse,
+  StorageResponse,
 } from "./assets_types";
 
 const ASSETS_BASE = "/api/assets";
+const STORAGE_BASE = "/api/storage";
 
 // 업로드 URL 발급
 export const getUploadUrl = async (
@@ -68,8 +70,20 @@ export const deleteAssetsBulk = async (
   data: BulkDeleteRequest,
 ): Promise<ApiResponse<BulkDeleteResponse>> => {
   const response = await apiClient.delete<ApiResponse<BulkDeleteResponse>>(
-    `/api/storage/assets`,
+    `${STORAGE_BASE}/assets`,
     { data },
+  );
+  return response.data;
+};
+
+// 스토리지 사용량 조회
+export const getStorageUsage = async (
+  keyword?: string,
+): Promise<ApiResponse<StorageResponse>> => {
+  const params = keyword ? { keyword } : undefined;
+  const response = await apiClient.get<ApiResponse<StorageResponse>>(
+    STORAGE_BASE,
+    { params },
   );
   return response.data;
 };

--- a/src/features/storage/api/assets_types.ts
+++ b/src/features/storage/api/assets_types.ts
@@ -106,3 +106,48 @@ export type AssetDetail = AssetDetailResponse;
 export interface AssetDeleteRequest {
   assetIds: string[];
 }
+
+// ============================================================
+// Storage API 타입
+// ============================================================
+
+/** 자산 요약 정보 (스토리지 페이지용) */
+export interface AssetSummaryDto {
+  assetId: number;
+  fileName: string;
+  fileSize: number;
+  mimeType: string;
+  fileCategory: "document" | "image";
+  source: "upload" | "ai_generated";
+  ocrStatus: "pending" | "processing" | "completed" | "failed";
+  thumbnailUrl: string | null;
+  createdAt: string;
+}
+
+/** 노트별 스토리지 정보 */
+export interface NoteStorageDto {
+  noteId: number;
+  title: string;
+  storageUsed: number; // MB 단위
+  storageLimit: number; // MB 단위 (고정 512MB)
+  storageUsedDisplay: string; // "120MB"
+  storageLimitDisplay: string; // "512MB"
+  assets: AssetSummaryDto[];
+}
+
+/** 플랜 정보 */
+export interface PlanDto {
+  planType: "free" | "standard" | "pro";
+  isActive: boolean;
+}
+
+/** 스토리지 사용량 조회 응답 */
+export interface StorageResponse {
+  totalUsed: number; // MB 단위
+  totalLimit: number; // MB 단위
+  totalUsedDisplay: string; // "240MB" or "1.5GB"
+  totalLimitDisplay: string; // "1GB", "5GB", "10GB"
+  usagePercent: number; // 0-100
+  plan: PlanDto;
+  notes: NoteStorageDto[];
+}

--- a/src/features/storage/components/NoteCard.tsx
+++ b/src/features/storage/components/NoteCard.tsx
@@ -3,20 +3,24 @@ import {
   StorageCheckboxUncheckedIcon,
   StorageCheckboxCheckedIcon,
 } from "../../../shared/components/icons/StorageIcons";
-import { PdfPreview } from "../../../shared/components/pdf-preview/PdfPreview";
-
-// API 명세서의 ocrStatus 타입을 반영
-type OcrStatus = "pending" | "processing" | "completed" | "failed";
+import {
+  getBadgeColor,
+  getBadgeText,
+  type AssetSourceType,
+  type AssetCategoryType,
+  type OcrStatusType,
+} from "../utils/asset-mapper";
 
 interface NoteCardProps {
-  label: string; // fileName
-  type: "upload" | "ai"; // source 필드 기반
+  label: string; // 파일명
+  type: AssetSourceType; // 파일 출처 ("upload" | "ai")
   isSelected: boolean;
   isSelectMode: boolean;
   onSelect: () => void;
-  fileUrl?: string;
+  thumbnailUrl?: string | null; // 썸네일 URL (백엔드 제공)
   mimeType?: string;
-  ocrStatus?: OcrStatus;
+  fileCategory?: AssetCategoryType;
+  ocrStatus?: OcrStatusType;
   onClick?: () => void;
 }
 
@@ -26,13 +30,87 @@ export const NoteCard = ({
   isSelected,
   isSelectMode,
   onSelect,
-  fileUrl,
+  thumbnailUrl,
   mimeType,
+  fileCategory,
   ocrStatus = "completed",
   onClick,
 }: NoteCardProps) => {
-  // 소스에 따른 배지 텍스트 결정
-  const badgeText = type === "upload" ? "업로드" : "AI 생성";
+  // 파일 출처에 따른 배지 정보
+  const badgeText = getBadgeText(type);
+  const badgeColor = getBadgeColor(type);
+
+  // 썸네일 렌더링 로직
+  const renderThumbnail = () => {
+    // OCR 처리 중일 때
+    if (ocrStatus === "pending" || ocrStatus === "processing") {
+      return (
+        <div className="flex flex-col items-center gap-2">
+          <LoadingSpinner size={40} />
+          <p className="text-[12px] font-medium text-blue-600">분석 중...</p>
+        </div>
+      );
+    }
+
+    // 썸네일 URL이 있으면 항상 이미지로 렌더링 (PDF 썸네일 포함)
+    if (thumbnailUrl) {
+      return (
+        <img
+          src={thumbnailUrl}
+          alt={label}
+          className="h-full w-full object-contain"
+          onError={(e) => {
+            // 이미지 로드 실패 시 fallback
+            e.currentTarget.style.display = "none";
+            e.currentTarget.parentElement!.innerHTML =
+              '<p class="text-[13px] text-gray-400">썸네일 없음</p>';
+          }}
+        />
+      );
+    }
+
+    // 썸네일이 없을 때 파일 타입에 따른 기본 아이콘 표시
+    return (
+      <div className="flex flex-col items-center gap-2">
+        <div className="flex h-16 w-16 items-center justify-center rounded-lg bg-gray-200">
+          {fileCategory === "document" || mimeType === "application/pdf" ? (
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              className="text-gray-500"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+              />
+            </svg>
+          ) : (
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              className="text-gray-500"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          )}
+        </div>
+        <p className="text-[11px] text-gray-400">썸네일 없음</p>
+      </div>
+    );
+  };
 
   return (
     <div
@@ -47,7 +125,7 @@ export const NoteCard = ({
         overflow: "hidden",
       }}
     >
-      {/* 1. 썸네일 영역: 파일 형식 및 OCR 상태에 따라 다르게 렌더링 */}
+      {/* 썸네일 영역 */}
       <div
         className="relative flex items-center justify-center overflow-hidden"
         style={{
@@ -68,36 +146,12 @@ export const NoteCard = ({
           </div>
         )}
 
-        {/* 실제 파일 미리보기 로직 */}
+        {/* 썸네일 렌더링 */}
         <div className="flex h-full w-full items-center justify-center p-2">
-          {ocrStatus === "pending" || ocrStatus === "processing" ? (
-            // 분석 중일 때 보여줄 로딩 뷰
-            <div className="flex flex-col items-center gap-2">
-              <LoadingSpinner size={40} />
-              <p className="text-[12px] font-medium text-blue-600">
-                분석 중...
-              </p>
-            </div>
-          ) : fileUrl ? (
-            // 완료 상태일 때 파일 타입별 렌더링
-            mimeType === "application/pdf" ? (
-              <PdfPreview
-                fileUrl={fileUrl}
-                width={120}
-              />
-            ) : (
-              <img
-                src={fileUrl}
-                alt={label}
-                className="h-full w-full object-cover"
-              />
-            )
-          ) : (
-            <p className="text-[13px] text-gray-400">이미지 없음</p>
-          )}
+          {renderThumbnail()}
         </div>
 
-        {/* 2. 업로드 배지: source 필드값에 따라 색상 변경 */}
+        {/* 업로드/AI 생성 배지 */}
         <div
           style={{
             position: "absolute",
@@ -109,7 +163,7 @@ export const NoteCard = ({
             justifyContent: "center",
             alignItems: "center",
             borderRadius: "10px",
-            background: type === "upload" ? "#003880" : "#E2A242",
+            background: badgeColor,
             zIndex: 10,
           }}
         >
@@ -119,7 +173,7 @@ export const NoteCard = ({
         </div>
       </div>
 
-      {/* 3. 파일명 영역 */}
+      {/* 파일명 영역 */}
       <div
         className="flex items-center"
         style={{

--- a/src/features/storage/components/NoteGroup.tsx
+++ b/src/features/storage/components/NoteGroup.tsx
@@ -1,14 +1,15 @@
 import { StorageChevronIcon } from "../../../shared/components/icons/StorageIcons";
 import { NoteCard } from "./NoteCard";
 import { useStorageStore } from "../store/useStorageStore";
-import type { AssetDetailResponseData } from "@/features/assets/types/asset";
+import type { AssetSummaryDto } from "../api/assets_types";
+import { mapAssetSource, mapAssetCategory, mapOcrStatus } from "../utils/asset-mapper";
 
 interface NoteGroupProps {
   title: string;
   storageUsedDisplay: string;
   storageLimitDisplay: string;
   usagePercent: number;
-  notes: AssetDetailResponseData[];
+  notes: AssetSummaryDto[];
   isOpen: boolean;
   onToggle: () => void;
 }
@@ -90,21 +91,20 @@ export const NoteGroup = ({
 
       {isOpen && (
         <div className="3xl:grid-cols-5 mx-auto mt-[20px] grid w-full grid-cols-2 justify-center gap-x-[40px] gap-y-[20px] lg:grid-cols-3 2xl:grid-cols-4">
-          {notes.map((asset) => {
-            return (
-              <NoteCard
-                key={asset.assetId}
-                label={asset.fileName}
-                type={asset.source === "upload" ? "upload" : "ai"}
-                fileUrl={asset.thumbnailUrl || undefined}
-                mimeType={asset.mimeType}
-                ocrStatus={asset.ocrStatus}
-                isSelected={selectedIds.includes(asset.assetId)}
-                isSelectMode={isSelectMode}
-                onSelect={() => toggleIdSelection(asset.assetId)}
-              />
-            );
-          })}
+          {notes.map((asset) => (
+            <NoteCard
+              key={asset.assetId}
+              label={asset.fileName}
+              type={mapAssetSource(asset.source)}
+              thumbnailUrl={asset.thumbnailUrl}
+              mimeType={asset.mimeType}
+              fileCategory={mapAssetCategory(asset.fileCategory)}
+              ocrStatus={mapOcrStatus(asset.ocrStatus)}
+              isSelected={selectedIds.includes(asset.assetId)}
+              isSelectMode={isSelectMode}
+              onSelect={() => toggleIdSelection(asset.assetId)}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/src/features/storage/hooks/useAssets.ts
+++ b/src/features/storage/hooks/useAssets.ts
@@ -5,43 +5,99 @@ import {
   getAssetDetail,
   getDownloadUrl,
   deleteAsset,
-  deleteAssets,
-  uploadToS3,
-  getStorageInfo,
-} from "@/features/assets/api/assetApi";
-import type { UploadUrlRequest } from "@/features/assets/types/asset";
+  deleteAssetsBulk,
+  getStorageUsage,
+} from "../api/assets_api";
+import type {
+  UploadUrlRequest,
+  StorageResponse,
+} from "../api/assets_types";
 
 // Query Keys
 export const assetKeys = {
   all: ["assets"] as const,
   storage: ["storage"] as const,
+  storageList: (keyword?: string) =>
+    keyword ? [...assetKeys.storage, "list", keyword] : [...assetKeys.storage, "list"] as const,
   details: () => [...assetKeys.all, "detail"] as const,
   detail: (id: number) => [...assetKeys.details(), id] as const,
 };
 
-// 전체 저장소 사용량 및 현황 조회 Hook
+/**
+ * 스토리지 사용량 조회 Hook
+ *
+ * TanStack Query 캐싱 전략:
+ * - staleTime: 5분 - 데이터가 5분간 fresh 상태 유지 (재요청 없음)
+ * - gcTime: 10분 - 사용하지 않는 데이터는 10분 후 가비지 컬렉션
+ * - refetchOnWindowFocus: false - 탭 이동 시 재요청 방지
+ * - refetchOnMount: false - 컴포넌트 재마운트 시 캐시된 데이터 사용
+ */
 export const useStorageInfo = (keyword?: string) => {
-  return useQuery({
-    queryKey: keyword ? [...assetKeys.storage, keyword] : assetKeys.storage,
+  return useQuery<StorageResponse>({
+    queryKey: assetKeys.storageList(keyword),
     queryFn: async () => {
-      const response = await getStorageInfo(keyword);
-      return response.result;
+      const response = await getStorageUsage(keyword);
+      return response.data;
     },
-    staleTime: 1000 * 60 * 10,
-    enabled: !keyword || keyword.length >= 2,
+    staleTime: 1000 * 60 * 5, // 5분간 fresh 상태 유지
+    gcTime: 1000 * 60 * 10, // 10분간 캐시 보관
+    refetchOnWindowFocus: false, // 탭 이동 시 재요청 방지
+    refetchOnMount: false, // 마운트 시 캐시 우선 사용
+    retry: 2, // 실패 시 2회 재시도
   });
 };
 
-// 에셋 상세 조회 Hook
+/**
+ * 에셋 상세 조회 Hook
+ *
+ * OCR 결과 등 상세 정보는 자주 변경되지 않으므로 긴 캐시 시간 사용
+ */
 export const useAssetDetail = (assetId: number, enabled = true) => {
   return useQuery({
     queryKey: assetKeys.detail(assetId),
     queryFn: async () => {
       const response = await getAssetDetail(assetId);
-      return response.result;
+      return response.data;
     },
     enabled: enabled && !!assetId,
     staleTime: 1000 * 60 * 10, // 10분
+    gcTime: 1000 * 60 * 15, // 15분간 캐시 보관
+    refetchOnWindowFocus: false,
+  });
+};
+
+// S3 직접 업로드 함수
+const uploadToS3 = async (
+  uploadUrl: string,
+  file: File,
+  onProgress?: (progress: number) => void,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    if (onProgress) {
+      xhr.upload.addEventListener("progress", (e) => {
+        if (e.lengthComputable) {
+          const percentComplete = Math.round((e.loaded / e.total) * 100);
+          onProgress(percentComplete);
+        }
+      });
+    }
+
+    xhr.addEventListener("load", () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve();
+      } else {
+        reject(new Error(`Upload failed with status ${xhr.status}`));
+      }
+    });
+
+    xhr.addEventListener("error", () => reject(new Error("Upload failed")));
+    xhr.addEventListener("abort", () => reject(new Error("Upload aborted")));
+
+    xhr.open("PUT", uploadUrl);
+    xhr.setRequestHeader("Content-Type", file.type);
+    xhr.send(file);
   });
 };
 
@@ -67,14 +123,14 @@ export const useUploadAsset = () => {
         fileSize: file.size,
       };
       const urlResponse = await getUploadUrl(requestParams);
-      const { uploadUrl, assetId } = urlResponse.result;
+      const { uploadUrl, assetId } = urlResponse.data;
 
-      // 2. S3에 직접 업로드 (assetApi의 uploadToS3 사용)
+      // 2. S3에 직접 업로드
       await uploadToS3(uploadUrl, file, onProgress);
 
       // 3. 업로드 완료 확인
       const confirmResponse = await confirmUpload(assetId);
-      return confirmResponse.result;
+      return confirmResponse.data;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: assetKeys.all });
@@ -83,16 +139,22 @@ export const useUploadAsset = () => {
   });
 };
 
-// 다운로드 URL 조회 Hook
+/**
+ * 다운로드 URL 조회 Hook
+ *
+ * Presigned URL은 15분간 유효하므로, 10분 캐시로 안전하게 사용
+ */
 export const useDownloadUrl = (assetId: number, enabled = false) => {
   return useQuery({
     queryKey: [...assetKeys.detail(assetId), "download"],
     queryFn: async () => {
       const response = await getDownloadUrl(assetId);
-      return response.result;
+      return response.data;
     },
     enabled: enabled && !!assetId,
-    staleTime: 1000 * 60 * 5, // 5분 (presigned URL 유효시간 고려)
+    staleTime: 1000 * 60 * 10, // 10분 (presigned URL 15분 유효)
+    gcTime: 1000 * 60 * 12, // 12분간 캐시 보관
+    refetchOnWindowFocus: false,
   });
 };
 
@@ -105,6 +167,7 @@ export const useDeleteAsset = () => {
     onSuccess: (_, assetId) => {
       queryClient.removeQueries({ queryKey: assetKeys.detail(assetId) });
       queryClient.invalidateQueries({ queryKey: assetKeys.all });
+      queryClient.invalidateQueries({ queryKey: assetKeys.storage });
     },
   });
 };
@@ -114,7 +177,8 @@ export const useDeleteAssetsBulk = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (assetIds: number[]) => deleteAssets(assetIds),
+    mutationFn: (assetIds: number[]) =>
+      deleteAssetsBulk({ assetIds }),
     onSuccess: (_, assetIds) => {
       assetIds.forEach((id) => {
         queryClient.removeQueries({ queryKey: assetKeys.detail(id) });

--- a/src/features/storage/pages/StoragePage.tsx
+++ b/src/features/storage/pages/StoragePage.tsx
@@ -15,6 +15,11 @@ import { StorageToolbar } from "../components/StorageToolbar";
 import { NoteGroup } from "../components/NoteGroup";
 import { DeleteNotesModal } from "../components/DeleteNotesModal";
 import { DeletionSuccessModal } from "../components/DeletionSuccessModal";
+import { useAuthStore } from "@/features/auth/store/auth_store"; // Import auth store
+import {
+  PLAN_DETAILS,
+  type PlanType,
+} from "@/features/subscription/types/plan_types"; // Import plan details
 
 export const StoragePage = () => {
   const [keyword, setKeyword] = useState("");
@@ -23,49 +28,49 @@ export const StoragePage = () => {
   const [openNoteIds, setOpenNoteIds] = useState<number[]>([]);
 
   const { isDeleteModalOpen, isSuccessModalOpen } = useStorageStore();
-  // TODO: 서버 데이터 연결 시 주석 해제
-  // const { data, isLoading } = useStorageInfo(keyword);
+  const { user } = useAuthStore(); // Get current user
+
+  // 노트당 최대 용량 계산 (512MB)
+  // Logic: All plans have 512MB per note limit (Total Storage / Max Notes)
+  // Free: 1GB / 2 = 512MB
+  // Standard: 5GB / 10 = 512MB
+  // Pro: 10GB / 20 = 512MB
+  const NOTE_STORAGE_LIMIT_BYTES = 512 * 1024 * 1024;
+  const NOTE_STORAGE_LIMIT_DISPLAY = "512MB";
 
   // MOCK DATA FOR UI VERIFICATION
   const isLoading = false;
+
+  // 사용자 플랜에 따른 전체 용량 정보 (mock)
+  const userPlanType = (user?.plan as PlanType) || "Free";
+  const planDetails = PLAN_DETAILS[userPlanType];
+
   const data = {
     totalUsed: 251658240,
-    totalLimit: 524288000,
+    totalLimit:
+      parseInt(planDetails.storage.replace("GB", "")) * 1024 * 1024 * 1024, // Parse based on plan
     totalUsedDisplay: "240MB",
-    totalLimitDisplay: "500MB",
+    totalLimitDisplay: planDetails.storage,
     usagePercent: 48,
     plan: {
-      planType: "free" as const,
+      planType: userPlanType,
       isActive: true,
     },
     notes: [
       {
         noteId: 1,
         title: "컴퓨터 구조 (CSED311)",
-        storageUsed: 125829120,
-        storageLimit: 262144000,
-        storageUsedDisplay: "120MB",
-        storageLimitDisplay: "250MB",
+        storageUsed: 126353920, // ~120.5MB
+        // storageLimit: NOTE_STORAGE_LIMIT_BYTES, // Derived in render
         assets: [
           {
             assetId: 101,
             source: "upload" as const,
             fileName: "Lecture_01_Intro.pdf",
-            fileSize: 10485760,
+            fileSize: 126353920,
             mimeType: "application/pdf",
             ocrStatus: "completed" as const,
             createdAt: "2024-02-09T09:00:00Z",
-            thumbnailUrl: null,
-            fileCategory: "document" as const,
-          },
-          {
-            assetId: 102,
-            source: "ai_generated" as const,
-            fileName: "Lecture_01_Summary.md",
-            fileSize: 5120,
-            mimeType: "text/markdown",
-            ocrStatus: "completed" as const,
-            createdAt: "2024-02-09T10:00:00Z",
             thumbnailUrl: null,
             fileCategory: "document" as const,
           },
@@ -74,32 +79,18 @@ export const StoragePage = () => {
       {
         noteId: 2,
         title: "운영체제 (CSED312)",
-        storageUsed: 52428800,
-        storageLimit: 262144000,
-        storageUsedDisplay: "50MB",
-        storageLimitDisplay: "250MB",
+        storageUsed: 52428800, // 50MB
         assets: [
           {
             assetId: 201,
             source: "upload" as const,
             fileName: "Process_Synchronization.pdf",
-            fileSize: 15728640,
+            fileSize: 52428800,
             mimeType: "application/pdf",
             ocrStatus: "processing" as const,
             createdAt: "2024-02-09T11:00:00Z",
             thumbnailUrl: null,
             fileCategory: "document" as const,
-          },
-          {
-            assetId: 202,
-            source: "upload" as const,
-            fileName: "Memory_Management_Graph.png",
-            fileSize: 204800,
-            mimeType: "image/png",
-            ocrStatus: "completed" as const,
-            createdAt: "2024-02-09T12:00:00Z",
-            thumbnailUrl: "https://placehold.co/400x300/png",
-            fileCategory: "image" as const,
           },
         ],
       },
@@ -121,6 +112,11 @@ export const StoragePage = () => {
 
   // keyword 사용 (lint 경고 방지)
   void keyword;
+
+  const formatBytesToMB = (bytes: number) => {
+    const mb = bytes / (1024 * 1024);
+    return Number.isInteger(mb) ? mb.toFixed(0) : mb.toFixed(1);
+  };
 
   return (
     <>
@@ -150,22 +146,24 @@ export const StoragePage = () => {
             {isLoading ? (
               <p>데이터를 불러오는 중입니다...</p>
             ) : (
-              data?.notes.map((note) => (
-                <NoteGroup
-                  key={note.noteId}
-                  title={note.title}
-                  storageUsedDisplay={note.storageUsedDisplay}
-                  storageLimitDisplay={note.storageLimitDisplay}
-                  usagePercent={
-                    note.storageLimit > 0
-                      ? (note.storageUsed / note.storageLimit) * 100
-                      : 0
-                  }
-                  notes={note.assets}
-                  isOpen={openNoteIds.includes(note.noteId)}
-                  onToggle={() => handleToggle(note.noteId)}
-                />
-              ))
+              data?.notes.map((note) => {
+                const usedMBDisplay = `${formatBytesToMB(note.storageUsed)}MB`;
+                const usagePercent =
+                  (note.storageUsed / NOTE_STORAGE_LIMIT_BYTES) * 100;
+
+                return (
+                  <NoteGroup
+                    key={note.noteId}
+                    title={note.title}
+                    storageUsedDisplay={usedMBDisplay}
+                    storageLimitDisplay={NOTE_STORAGE_LIMIT_DISPLAY}
+                    usagePercent={Math.min(usagePercent, 100)} // Cap at 100%
+                    notes={note.assets}
+                    isOpen={openNoteIds.includes(note.noteId)}
+                    onToggle={() => handleToggle(note.noteId)}
+                  />
+                );
+              })
             )}
           </div>
         </div>

--- a/src/features/storage/pages/StoragePage.tsx
+++ b/src/features/storage/pages/StoragePage.tsx
@@ -15,87 +15,16 @@ import { StorageToolbar } from "../components/StorageToolbar";
 import { NoteGroup } from "../components/NoteGroup";
 import { DeleteNotesModal } from "../components/DeleteNotesModal";
 import { DeletionSuccessModal } from "../components/DeletionSuccessModal";
-import { useAuthStore } from "@/features/auth/store/auth_store"; // Import auth store
-import {
-  PLAN_DETAILS,
-  type PlanType,
-} from "@/features/subscription/types/plan_types"; // Import plan details
+import { useStorageInfo } from "../hooks/useAssets";
 
 export const StoragePage = () => {
   const [keyword, setKeyword] = useState("");
-
-  // 동적으로 열려 있는 노트 그룹 ID 관리
   const [openNoteIds, setOpenNoteIds] = useState<number[]>([]);
 
   const { isDeleteModalOpen, isSuccessModalOpen } = useStorageStore();
-  const { user } = useAuthStore(); // Get current user
 
-  // 노트당 최대 용량 계산 (512MB)
-  // Logic: All plans have 512MB per note limit (Total Storage / Max Notes)
-  // Free: 1GB / 2 = 512MB
-  // Standard: 5GB / 10 = 512MB
-  // Pro: 10GB / 20 = 512MB
-  const NOTE_STORAGE_LIMIT_BYTES = 512 * 1024 * 1024;
-  const NOTE_STORAGE_LIMIT_DISPLAY = "512MB";
-
-  // MOCK DATA FOR UI VERIFICATION
-  const isLoading = false;
-
-  // 사용자 플랜에 따른 전체 용량 정보 (mock)
-  const userPlanType = (user?.plan as PlanType) || "Free";
-  const planDetails = PLAN_DETAILS[userPlanType];
-
-  const data = {
-    totalUsed: 251658240,
-    totalLimit:
-      parseInt(planDetails.storage.replace("GB", "")) * 1024 * 1024 * 1024, // Parse based on plan
-    totalUsedDisplay: "240MB",
-    totalLimitDisplay: planDetails.storage,
-    usagePercent: 48,
-    plan: {
-      planType: userPlanType,
-      isActive: true,
-    },
-    notes: [
-      {
-        noteId: 1,
-        title: "컴퓨터 구조 (CSED311)",
-        storageUsed: 126353920, // ~120.5MB
-        // storageLimit: NOTE_STORAGE_LIMIT_BYTES, // Derived in render
-        assets: [
-          {
-            assetId: 101,
-            source: "upload" as const,
-            fileName: "Lecture_01_Intro.pdf",
-            fileSize: 126353920,
-            mimeType: "application/pdf",
-            ocrStatus: "completed" as const,
-            createdAt: "2024-02-09T09:00:00Z",
-            thumbnailUrl: null,
-            fileCategory: "document" as const,
-          },
-        ],
-      },
-      {
-        noteId: 2,
-        title: "운영체제 (CSED312)",
-        storageUsed: 52428800, // 50MB
-        assets: [
-          {
-            assetId: 201,
-            source: "upload" as const,
-            fileName: "Process_Synchronization.pdf",
-            fileSize: 52428800,
-            mimeType: "application/pdf",
-            ocrStatus: "processing" as const,
-            createdAt: "2024-02-09T11:00:00Z",
-            thumbnailUrl: null,
-            fileCategory: "document" as const,
-          },
-        ],
-      },
-    ],
-  };
+  // API를 통한 스토리지 정보 조회
+  const { data, isLoading, error } = useStorageInfo(keyword);
 
   // 노트 그룹 토글 핸들러
   const handleToggle = (noteId: number) => {
@@ -108,14 +37,6 @@ export const StoragePage = () => {
 
   const handleSearch = (value: string) => {
     setKeyword(value);
-  };
-
-  // keyword 사용 (lint 경고 방지)
-  void keyword;
-
-  const formatBytesToMB = (bytes: number) => {
-    const mb = bytes / (1024 * 1024);
-    return Number.isInteger(mb) ? mb.toFixed(0) : mb.toFixed(1);
   };
 
   return (
@@ -135,8 +56,8 @@ export const StoragePage = () => {
           <div className="flex justify-center">
             <StorageToolbar
               usagePercent={data?.usagePercent ?? 0}
-              totalUsedDisplay={data?.totalUsedDisplay ?? "0GB"}
-              totalLimitDisplay={data?.totalLimitDisplay ?? "0GB"}
+              totalUsedDisplay={data?.totalUsedDisplay ?? "0MB"}
+              totalLimitDisplay={data?.totalLimitDisplay ?? "0MB"}
               onSearch={handleSearch}
             />
           </div>
@@ -145,25 +66,28 @@ export const StoragePage = () => {
           <div className="mt-[24px] flex flex-col items-center justify-center gap-[20px]">
             {isLoading ? (
               <p>데이터를 불러오는 중입니다...</p>
+            ) : error ? (
+              <p className="text-red-500">
+                데이터를 불러오는 중 오류가 발생했습니다.
+              </p>
+            ) : data?.notes && data.notes.length > 0 ? (
+              data.notes.map((note) => (
+                <NoteGroup
+                  key={note.noteId}
+                  title={note.title}
+                  storageUsedDisplay={note.storageUsedDisplay}
+                  storageLimitDisplay={note.storageLimitDisplay}
+                  usagePercent={Math.min(
+                    (note.storageUsed / note.storageLimit) * 100,
+                    100,
+                  )}
+                  notes={note.assets}
+                  isOpen={openNoteIds.includes(note.noteId)}
+                  onToggle={() => handleToggle(note.noteId)}
+                />
+              ))
             ) : (
-              data?.notes.map((note) => {
-                const usedMBDisplay = `${formatBytesToMB(note.storageUsed)}MB`;
-                const usagePercent =
-                  (note.storageUsed / NOTE_STORAGE_LIMIT_BYTES) * 100;
-
-                return (
-                  <NoteGroup
-                    key={note.noteId}
-                    title={note.title}
-                    storageUsedDisplay={usedMBDisplay}
-                    storageLimitDisplay={NOTE_STORAGE_LIMIT_DISPLAY}
-                    usagePercent={Math.min(usagePercent, 100)} // Cap at 100%
-                    notes={note.assets}
-                    isOpen={openNoteIds.includes(note.noteId)}
-                    onToggle={() => handleToggle(note.noteId)}
-                  />
-                );
-              })
+              <p className="text-gray-500">저장된 파일이 없습니다.</p>
             )}
           </div>
         </div>

--- a/src/features/storage/store/useStorageStore.ts
+++ b/src/features/storage/store/useStorageStore.ts
@@ -26,6 +26,9 @@ interface StorageState {
   setNotes: (notes: Note[]) => void;
   addNote: (note: Note) => void;
   deleteSelectedNotes: () => void;
+
+  viewerFileId: number | null;
+  setViewerFileId: (id: number | null) => void;
 }
 
 export const useStorageStore = create<StorageState>((set) => ({
@@ -68,4 +71,7 @@ export const useStorageStore = create<StorageState>((set) => ({
       isDeleteModalOpen: false,
       isSuccessModalOpen: true,
     })),
+
+  viewerFileId: null,
+  setViewerFileId: (id) => set({ viewerFileId: id }),
 }));

--- a/src/features/storage/utils/asset-mapper.ts
+++ b/src/features/storage/utils/asset-mapper.ts
@@ -1,0 +1,141 @@
+/**
+ * 자산(Asset) 관련 유틸리티 함수
+ *
+ * 백엔드 API 응답을 프론트엔드 컴포넌트에서 사용하기 쉽게 변환
+ */
+
+import type { AssetSummaryDto } from "../api/assets_types";
+
+/**
+ * 파일 출처 타입
+ * - upload: 사용자가 직접 업로드한 파일
+ * - ai_generated: AI가 생성한 파일
+ */
+export type AssetSourceType = "upload" | "ai";
+
+/**
+ * 파일 카테고리 타입
+ * - document: 문서 (PDF 등)
+ * - image: 이미지 (PNG, JPEG, WEBP 등)
+ */
+export type AssetCategoryType = "document" | "image";
+
+/**
+ * OCR 처리 상태
+ */
+export type OcrStatusType = "pending" | "processing" | "completed" | "failed";
+
+/**
+ * NoteCard 컴포넌트에서 사용할 자산 정보
+ */
+export interface AssetCardInfo {
+  assetId: number;
+  fileName: string;
+  fileSize: number;
+  sourceType: AssetSourceType;
+  category: AssetCategoryType;
+  ocrStatus: OcrStatusType;
+  thumbnailUrl: string | null;
+  mimeType: string;
+  createdAt: string;
+}
+
+/**
+ * 백엔드 source 값을 프론트엔드 타입으로 매핑
+ *
+ * @param source - 백엔드 API의 source 값 ("upload" | "ai_generated")
+ * @returns AssetSourceType ("upload" | "ai")
+ */
+export const mapAssetSource = (source: string): AssetSourceType => {
+  return source === "ai_generated" ? "ai" : "upload";
+};
+
+/**
+ * 파일 카테고리 매핑
+ *
+ * @param category - 백엔드 API의 fileCategory 값
+ * @returns AssetCategoryType
+ */
+export const mapAssetCategory = (
+  category: string,
+): AssetCategoryType => {
+  return category === "image" ? "image" : "document";
+};
+
+/**
+ * OCR 상태 매핑
+ *
+ * @param status - 백엔드 API의 ocrStatus 값
+ * @returns OcrStatusType
+ */
+export const mapOcrStatus = (status: string): OcrStatusType => {
+  const validStatuses: OcrStatusType[] = [
+    "pending",
+    "processing",
+    "completed",
+    "failed",
+  ];
+  return validStatuses.includes(status as OcrStatusType)
+    ? (status as OcrStatusType)
+    : "pending";
+};
+
+/**
+ * AssetSummaryDto를 AssetCardInfo로 변환
+ *
+ * 백엔드 API 응답을 프론트엔드 컴포넌트에서 사용하기 쉬운 형태로 변환
+ *
+ * @param asset - 백엔드 API의 AssetSummaryDto
+ * @returns AssetCardInfo
+ */
+export const mapAssetToCardInfo = (
+  asset: AssetSummaryDto,
+): AssetCardInfo => {
+  return {
+    assetId: asset.assetId,
+    fileName: asset.fileName,
+    fileSize: asset.fileSize,
+    sourceType: mapAssetSource(asset.source),
+    category: mapAssetCategory(asset.fileCategory),
+    ocrStatus: mapOcrStatus(asset.ocrStatus),
+    thumbnailUrl: asset.thumbnailUrl,
+    mimeType: asset.mimeType,
+    createdAt: asset.createdAt,
+  };
+};
+
+/**
+ * 파일 크기를 사람이 읽기 쉬운 형식으로 변환
+ *
+ * @param bytes - 바이트 단위 파일 크기
+ * @returns 포맷팅된 문자열 (예: "1.5MB", "120KB")
+ */
+export const formatFileSize = (bytes: number): string => {
+  if (bytes === 0) return "0B";
+
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))}${sizes[i]}`;
+};
+
+/**
+ * 배지 색상 가져오기
+ *
+ * @param sourceType - 파일 출처 타입
+ * @returns 배지 배경색 (HEX)
+ */
+export const getBadgeColor = (sourceType: AssetSourceType): string => {
+  return sourceType === "upload" ? "#003880" : "#E2A242";
+};
+
+/**
+ * 배지 텍스트 가져오기
+ *
+ * @param sourceType - 파일 출처 타입
+ * @returns 배지 표시 텍스트
+ */
+export const getBadgeText = (sourceType: AssetSourceType): string => {
+  return sourceType === "upload" ? "업로드" : "AI 생성";
+};

--- a/src/features/subscription/types/plan_types.ts
+++ b/src/features/subscription/types/plan_types.ts
@@ -28,7 +28,7 @@ export const PLAN_DETAILS: Record<
     name: "Free",
     dailyCredits: 100,
     monthlyCredits: 0,
-    storage: "5GB",
+    storage: "1GB",
     maxNotes: 2,
     maxUploadSize: "10MB",
     price: 0,


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #125 

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용
- 스토리지 페이지에서 API를 통해 썸네일, OCR 상태 및 용량 정보를 처리하도록 수정
- 네트워크 요청 최적화 및 캐싱 최적화

## 📸 스크린샷


## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항
- API와 연동하여 실시간 데이터 반영이 가능하도록 개선되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * PDF 및 이미지 파일 뷰어 추가 (페이지 네비게이션 포함)
  * 노트 뷰어에 파일 업로드 기능 추가

* **변경 사항**
  * Free 플랜 스토리지 용량이 5GB에서 1GB로 변경
  * 사용자 플랜에 따른 동적 스토리지 용량 계산 적용

* **스타일**
  * 버튼의 커서 포인터 상태 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->