### PR TITLE
Refactor(#147): 노트 페이지네이션 수정 최대 6개씩

### DIFF
--- a/src/features/notes/components/NotesGrid.tsx
+++ b/src/features/notes/components/NotesGrid.tsx
@@ -14,6 +14,8 @@ interface NotesGridProps {
   isSelectMode: boolean;
   selectedIds: number[];
   onToggleSelection: (id: number) => void;
+  showAddCard?: boolean;
+  totalSlots?: number;
 }
 
 export const NotesGrid = ({
@@ -22,26 +24,40 @@ export const NotesGrid = ({
   isSelectMode,
   selectedIds,
   onToggleSelection,
+  showAddCard = false,
+  totalSlots = 6,
 }: NotesGridProps) => {
+  const usedSlots = (showAddCard ? 1 : 0) + notes.length;
+  const placeholderCount = Math.max(0, totalSlots - usedSlots);
+
   return (
     <div className="mt-[21px] w-full">
       <div className="grid [grid-template-columns:repeat(2,271px)] gap-[40px] min-[1340px]:[grid-template-columns:repeat(3,271px)]">
-        <NotesAddCard />
+        {showAddCard && <NotesAddCard />}
 
         {isLoading ? (
           <div className="col-span-full flex items-center justify-center py-[40px]">
             <LoadingSpinner size={80} />
           </div>
         ) : notes.length > 0 ? (
-          notes.map((note) => (
-            <NoteCard
-              key={note.noteId}
-              note={note}
-              isSelectMode={isSelectMode}
-              isSelected={selectedIds.includes(note.noteId)}
-              onToggleSelection={onToggleSelection}
-            />
-          ))
+          <>
+            {notes.map((note) => (
+              <NoteCard
+                key={note.noteId}
+                note={note}
+                isSelectMode={isSelectMode}
+                isSelected={selectedIds.includes(note.noteId)}
+                onToggleSelection={onToggleSelection}
+              />
+            ))}
+            {Array.from({ length: placeholderCount }).map((_, index) => (
+              <div
+                key={`placeholder-${index}`}
+                aria-hidden="true"
+                className="h-[229px] w-[271px] rounded-[12px] border-[0.5px] border-transparent bg-transparent"
+              />
+            ))}
+          </>
         ) : (
           <div className="col-span-full flex items-center justify-center py-[40px]">
             <span className="text-[14px] leading-[20px] text-[#6D6D6D]">

--- a/src/features/notes/hooks/useNoteListPage.ts
+++ b/src/features/notes/hooks/useNoteListPage.ts
@@ -18,7 +18,7 @@ export const useNoteListPage = () => {
   // API 데이터 조회
   const { data, isLoading, isError } = useNoteList({
     page: currentPage,
-    size: 20,
+    size: 6,
     sort: sortOrder,
   });
 

--- a/src/features/notes/pages/NotesPage.tsx
+++ b/src/features/notes/pages/NotesPage.tsx
@@ -47,6 +47,8 @@ export const NotesPage = () => {
     handleCloseSuccessModal,
   } = useNoteListPage();
 
+  const visibleNotes = currentPage === 0 ? notes.slice(0, 5) : notes;
+
   if (isError) {
     return (
       <div className="flex h-full w-full items-center justify-center bg-white">
@@ -82,11 +84,13 @@ export const NotesPage = () => {
           {/* 노트 그리드 영역 */}
           <div>
             <NotesGrid
-              notes={notes}
+              notes={visibleNotes}
               isLoading={isLoading}
               isSelectMode={isSelectMode}
               selectedIds={selectedIds}
               onToggleSelection={toggleIdSelection}
+              showAddCard={currentPage === 0}
+              totalSlots={6}
             />
           </div>
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #147 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 1번째 페이지 -> 노트 추가하기 + 최대 노트 5개
- 2번째 페이지부터 -> 최대 노트 6개

## 📸 스크린샷

<img width="1915" height="982" alt="image" src="https://github.com/user-attachments/assets/dce55012-6341-4934-8114-8b143d054cea" />


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **새로운 기능**
  * 노트 첫 페이지에 노트 추가 카드 표시
  * 그리드 레이아웃 일관성을 위한 플레이스홀더 카드 추가
  * 그리드 슬롯 및 추가 카드 표시 여부 커스터마이징 기능

* **개선사항**
  * 페이지당 로드되는 데이터 크기 조정으로 초기 페이지 로딩 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->