### PR TITLE
Fix(#151) : 스토리지 삭제 및 즉시 동기화(refetchQueries) 적용

### DIFF
--- a/src/features/assets/hooks/useAssetUpload.ts
+++ b/src/features/assets/hooks/useAssetUpload.ts
@@ -34,20 +34,24 @@ export const useAssetUpload = () => {
 
       // 3. 서버에 업로드 완료 확정 알림 (assetApi 사용)
       const confirmResponse = await confirmUpload(assetId);
-      console.log("서버 업로드 확정 완료:", confirmResponse.message);
+      console.log("✅ 업로드 확정 완료:", {
+        assetId,
+        fileName: confirmResponse.result.fileName,
+        ocrStatus: confirmResponse.result.ocrStatus,
+        thumbnailUrl: confirmResponse.result.thumbnailUrl,
+      });
 
-      // 쿼리 무효화 (노트 상세 + 저장소 정보 갱신 -> 모든 storage 관련 화면 동기화)
+      // 쿼리 즉시 갱신 (invalidate가 아닌 refetch 사용)
       await Promise.all([
-        queryClient.invalidateQueries({
+        queryClient.refetchQueries({
           queryKey: noteKeys.detail(String(noteId)),
         }),
-        queryClient.invalidateQueries({
+        queryClient.refetchQueries({
           queryKey: assetKeys.storage,
         }),
-        queryClient.invalidateQueries({
-          queryKey: assetKeys.all,
-        }),
       ]);
+
+      console.log("✅ 쿼리 갱신 완료");
 
       // 4. 업로드 성공 후 반환
       return confirmResponse.result;

--- a/src/features/chat/components/leftpanel/StorageActionButtons.tsx
+++ b/src/features/chat/components/leftpanel/StorageActionButtons.tsx
@@ -6,23 +6,29 @@ import {
 interface StorageActionButtonsProps {
   onOpenViewer: () => void;
   onDelete: () => void;
+  selectedCount: number;
 }
 
 export const StorageActionButtons = ({
   onOpenViewer,
   onDelete,
+  selectedCount,
 }: StorageActionButtonsProps) => {
+  const showViewer = selectedCount === 1;
+
   return (
-    <div className="flex h-[56px] w-[350px] shrink-0 items-center justify-center gap-4 rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-white py-[14px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.1)]">
-      {/* 뷰어에서 열기 버튼 */}
-      <button
-        onClick={onOpenViewer}
-        type="button"
-        className="flex h-[28px] w-[140px] shrink-0 items-center justify-center gap-1 rounded-lg bg-[#2A6AFF] text-base leading-6 text-white transition-colors hover:bg-[#2259DB]"
-      >
-        <ViewerOpenIcon size={24} />
-        <span className="whitespace-nowrap">뷰어에서 열기</span>
-      </button>
+    <div className={`flex h-[56px] shrink-0 items-center justify-center gap-4 rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-white py-[14px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.1)] ${showViewer ? 'w-[350px]' : 'w-[140px]'}`}>
+      {/* 뷰어에서 열기 버튼 - 1개만 선택했을 때만 표시 */}
+      {showViewer && (
+        <button
+          onClick={onOpenViewer}
+          type="button"
+          className="flex h-[28px] w-[140px] shrink-0 items-center justify-center gap-1 rounded-lg bg-[#2A6AFF] text-base leading-6 text-white transition-colors hover:bg-[#2259DB]"
+        >
+          <ViewerOpenIcon size={24} />
+          <span className="whitespace-nowrap">뷰어에서 열기</span>
+        </button>
+      )}
 
       {/* 삭제하기 버튼 */}
       <button

--- a/src/features/chat/components/leftpanel/StorageContent.tsx
+++ b/src/features/chat/components/leftpanel/StorageContent.tsx
@@ -48,8 +48,8 @@ export const StorageContent = ({
 }: StorageContentProps) => {
   const queryClient = useQueryClient();
   const [hasProcessingAssets, setHasProcessingAssets] = useState(false);
-  const { data: noteDetail } = useNoteDetail(noteId, undefined, {
-    refetchInterval: hasProcessingAssets ? 3000 : false,
+  const { data: noteDetail, refetch } = useNoteDetail(noteId, undefined, {
+    refetchInterval: hasProcessingAssets ? 2000 : false, // 2초로 단축
   });
   const { user } = useAuthStore();
 
@@ -61,7 +61,12 @@ export const StorageContent = ({
           asset.ocrStatus === "pending" || asset.ocrStatus === "processing",
       ) ?? false;
     setHasProcessingAssets(isProcessing);
-  }, [noteDetail]);
+
+    // 처리 중이던 에셋이 완료되면 한 번 더 갱신
+    if (!isProcessing && hasProcessingAssets) {
+      refetch();
+    }
+  }, [noteDetail, hasProcessingAssets, refetch]);
 
   // BOX 파일 목록 (업로드된 자산)
   const boxFiles = useMemo<StorageFile[]>(() => {
@@ -132,11 +137,10 @@ export const StorageContent = ({
       const response = await deleteAssets(targetIds);
 
       if (response.isSuccess) {
-        // 성공 시 쿼리 무효화하여 목록 갱신 (노트 상세 + 저장소 정보 모두 갱신)
+        // 쿼리 즉시 갱신 (refetch 사용)
         await Promise.all([
-          queryClient.invalidateQueries({ queryKey: noteKeys.detail(noteId) }),
-          queryClient.invalidateQueries({ queryKey: assetKeys.storage }),
-          queryClient.invalidateQueries({ queryKey: assetKeys.all }),
+          queryClient.refetchQueries({ queryKey: noteKeys.detail(noteId) }),
+          queryClient.refetchQueries({ queryKey: assetKeys.storage }),
         ]);
 
         setSelectedIds([]);
@@ -312,6 +316,7 @@ export const StorageContent = ({
             <StorageActionButtons
               onOpenViewer={handleOpenViewer}
               onDelete={handleDelete}
+              selectedCount={selectedIds.length}
             />
           </div>
         )}

--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -5,7 +5,7 @@ import {
   createConversation as createConversationApi,
   parseSSEStream,
 } from "@/features/editor/api/editor_api";
-import { useNoteDetail } from "@/features/notes/hooks/useNotes";
+import { useNoteDetail, noteKeys } from "@/features/notes/hooks/useNotes";
 import { uploadAttachments } from "@/features/assets/utils/upload_attachments";
 import type { ChatSendData } from "@/features/editor/components/ChatInput";
 import type { ConversationInfo } from "@/features/notes/api/notes_types";
@@ -13,6 +13,7 @@ import type { FirstMessageState } from "@/pages/hooks/useHomeSend";
 import type { ChatMessage, MessageAttachment } from "../types/chat_types";
 import { creditKeys } from "@/features/settings/hooks/useCredit";
 import { userKeys } from "@/features/settings/hooks/useUser";
+import { assetKeys } from "@/features/storage/hooks/useAssets";
 
 /** 서버 ConversationInfo[] → ChatMessage[] 변환 */
 const convertConversations = (
@@ -308,7 +309,12 @@ export const useChatMessages = () => {
           const result = await uploadAttachments(nId, data.attachments);
           uploadedFileAssetIds = result.fileAssetIds;
           canvasImageIds = result.canvasAssetIds;
-          queryClient.invalidateQueries({ queryKey: ["noteAssets", nId] });
+
+          // 쿼리 즉시 갱신
+          await Promise.all([
+            queryClient.refetchQueries({ queryKey: noteKeys.detail(String(nId)) }),
+            queryClient.refetchQueries({ queryKey: assetKeys.storage }),
+          ]);
         } catch (error) {
           console.error("[ChatPage] 첨부 파일 업로드 실패:", error);
           setIsUploading(false);

--- a/src/features/storage/components/DeleteNotesModal.tsx
+++ b/src/features/storage/components/DeleteNotesModal.tsx
@@ -1,8 +1,22 @@
 import { useStorageStore } from "../store/useStorageStore";
+import { useQueryClient } from "@tanstack/react-query";
+import { assetKeys } from "../hooks/useAssets";
+import { noteKeys } from "@/features/notes/hooks/useNotes";
 
 export const DeleteNotesModal = () => {
+  const queryClient = useQueryClient();
   const { setDeleteModalOpen, deleteSelectedNotes, selectedIds } =
     useStorageStore();
+
+  const handleDelete = async () => {
+    await deleteSelectedNotes();
+
+    // 쿼리 즉시 갱신 (refetch 사용)
+    await Promise.all([
+      queryClient.refetchQueries({ queryKey: assetKeys.storage }),
+      queryClient.refetchQueries({ queryKey: noteKeys.all }),
+    ]);
+  };
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
@@ -97,7 +111,7 @@ export const DeleteNotesModal = () => {
           </button>
 
           <button
-            onClick={deleteSelectedNotes}
+            onClick={handleDelete}
             style={{
               display: "flex",
               width: "240px",

--- a/src/features/storage/store/useStorageStore.ts
+++ b/src/features/storage/store/useStorageStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { deleteAssets } from "@/features/assets/api/assetApi";
 
 export interface Note {
   id: number;
@@ -25,7 +26,7 @@ interface StorageState {
   setSuccessModalOpen: (isOpen: boolean) => void;
   setNotes: (notes: Note[]) => void;
   addNote: (note: Note) => void;
-  deleteSelectedNotes: () => void;
+  deleteSelectedNotes: () => Promise<void>;
 
   viewerFileId: number | null;
   setViewerFileId: (id: number | null) => void;
@@ -61,16 +62,32 @@ export const useStorageStore = create<StorageState>((set) => ({
   setNotes: (noteCards) => set({ noteCards }),
   addNote: (note) =>
     set((state) => ({ noteCards: [note, ...state.noteCards] })),
-  deleteSelectedNotes: () =>
-    set((state) => ({
-      noteCards: state.noteCards.filter(
-        (note) => !state.selectedIds.includes(note.id),
-      ),
-      selectedIds: [],
-      isSelectMode: false,
-      isDeleteModalOpen: false,
-      isSuccessModalOpen: true,
-    })),
+  deleteSelectedNotes: async () => {
+    const state = useStorageStore.getState();
+    const { selectedIds } = state;
+
+    if (selectedIds.length === 0) return;
+
+    try {
+      // 실제 API 호출
+      await deleteAssets(selectedIds);
+
+      // 성공 시 상태 업데이트
+      set({
+        noteCards: state.noteCards.filter(
+          (note) => !selectedIds.includes(note.id),
+        ),
+        selectedIds: [],
+        isSelectMode: false,
+        isDeleteModalOpen: false,
+        isSuccessModalOpen: true,
+      });
+    } catch (error) {
+      console.error("파일 삭제 실패:", error);
+      alert("파일 삭제에 실패했습니다.");
+      set({ isDeleteModalOpen: false });
+    }
+  },
 
   viewerFileId: null,
   setViewerFileId: (id) => set({ viewerFileId: id }),


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #151 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 1) 저장소 삭제 문제 해결
- `deleteSelectedNotes`가 실제 API를 호출하도록 수정
- 삭제 후 쿼리 갱신으로 모든 화면 상태 동기화

### 2) 쿼리 갱신 방식 개선 (핵심)
- 기존: `invalidateQueries` (백그라운드 갱신으로 반영 지연 가능)
- 변경: `refetchQueries` (즉시 강제 갱신)

- 업로드/삭제 지점 전부 즉시 갱신 적용
  - `useAssetUpload.ts` (업로드 후)
  - `StorageContent.tsx` (노트 안 Storage 삭제 후)
  - `DeleteNotesModal.tsx` (저장소 페이지 삭제 후)
  - `useChatMessages.ts` (채팅 첨부파일 업로드 후)

### 3) 뷰어 버튼 조건부 표시
- 1개 선택 시: "뷰어에서 열기" + "삭제하기"
- 여러 개 선택 시: "삭제하기"만 표시

### 4) 폴링 주기 개선
- 3초 → 2초로 단축
- 처리 완료 시 추가 갱신 수행

### 5) 디버깅 로그 추가
- confirm 응답의 `ocrStatus`, `thumbnailUrl` 확인 로그 출력

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항
