### PR TITLE
Fix(#153) : 스토리지 동기화/경고메시지/멘션갱신 및 노트

### DIFF
--- a/src/features/assets/api/assetApi.ts
+++ b/src/features/assets/api/assetApi.ts
@@ -40,11 +40,13 @@ export const getUploadUrl = async (
 export const uploadToS3 = async (
   uploadUrl: string,
   file: File,
+  contentType?: string,
   onProgress?: (percentage: number) => void,
 ): Promise<void> => {
   await axios.put(uploadUrl, file, {
     headers: {
-      "Content-Type": file.type,
+      "Content-Type":
+        (contentType ?? file.type) || "application/octet-stream",
     },
     onUploadProgress: (e) => {
       if (e.total) {

--- a/src/features/assets/hooks/useAssetUpload.ts
+++ b/src/features/assets/hooks/useAssetUpload.ts
@@ -4,6 +4,7 @@ import type { UploadUrlRequest } from "../types/asset";
 import { getUploadUrl, uploadToS3, confirmUpload } from "../api/assetApi";
 import { noteKeys } from "@/features/notes/hooks/useNotes";
 import { assetKeys } from "@/features/storage/hooks/useAssets";
+import { resolveUploadMimeType } from "../utils/fileValidation";
 
 export const useAssetUpload = () => {
   const queryClient = useQueryClient();
@@ -16,10 +17,15 @@ export const useAssetUpload = () => {
     setProgress(0);
 
     try {
+      const mimeType = resolveUploadMimeType(file);
+      if (!mimeType) {
+        throw new Error("지원하지 않는 파일 형식입니다.");
+      }
+
       const requestParams: UploadUrlRequest = {
         noteId: noteId,
         fileName: file.name,
-        mimeType: file.type,
+        mimeType,
         fileSize: file.size,
       };
 
@@ -28,7 +34,7 @@ export const useAssetUpload = () => {
       const { uploadUrl, assetId } = uploadUrlResponse.result;
 
       // 2. S3에 파일 업로드 (진행률 반영, assetApi 사용)
-      await uploadToS3(uploadUrl, file, (percentage) => {
+      await uploadToS3(uploadUrl, file, mimeType, (percentage) => {
         setProgress(percentage);
       });
 

--- a/src/features/assets/utils/fileValidation.ts
+++ b/src/features/assets/utils/fileValidation.ts
@@ -8,6 +8,13 @@ export const ALLOWED_MIME_TYPES = [
 
 /** 확장자 기반 폴백 (file.type이 비어있을 때) */
 export const ALLOWED_EXTENSIONS = [".pdf", ".png", ".jpg", ".jpeg", ".webp"];
+const EXTENSION_TO_MIME: Record<string, string> = {
+  pdf: "application/pdf",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+};
 
 /** 최대 파일 크기: 30MB */
 export const MAX_FILE_SIZE = 30 * 1024 * 1024;
@@ -27,6 +34,20 @@ export const isFileAllowed = (file: File): boolean => {
 };
 
 /**
+ * 업로드에 사용할 MIME 타입 결정
+ * - file.type이 유효하면 그대로 사용
+ * - 비어있거나 비정상이면 확장자 기반으로 복원
+ */
+export const resolveUploadMimeType = (file: File): string | null => {
+  if (file.type && ALLOWED_MIME_TYPES.includes(file.type)) {
+    return file.type;
+  }
+  const ext = file.name.toLowerCase().split(".").pop();
+  if (!ext) return null;
+  return EXTENSION_TO_MIME[ext] ?? null;
+};
+
+/**
  * 파일 유효성 검증 (업로드 API 호출 전 사용)
  * - 실패 시 Error throw
  */
@@ -37,19 +58,10 @@ export const validateFile = (file: File) => {
   }
 
   // 2. 파일 형식 체크 (MIME → 확장자 폴백)
-  if (file.type) {
-    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
-      throw new Error(
-        "지원하지 않는 파일 형식입니다. PDF, PNG, JPEG, WEBP 파일만 업로드 가능합니다.",
-      );
-    }
-  } else {
-    const ext = file.name.toLowerCase().split(".").pop();
-    if (!ext || !ALLOWED_EXTENSIONS.includes(`.${ext}`)) {
-      throw new Error(
-        "지원하지 않는 파일 형식입니다. PDF, PNG, JPEG, WEBP 파일만 업로드 가능합니다.",
-      );
-    }
+  if (!resolveUploadMimeType(file)) {
+    throw new Error(
+      "지원하지 않는 파일 형식입니다. PDF, PNG, JPEG, WEBP 파일만 업로드 가능합니다.",
+    );
   }
 
   // 3. 파일명 길이 체크

--- a/src/features/assets/utils/upload_attachments.ts
+++ b/src/features/assets/utils/upload_attachments.ts
@@ -1,5 +1,6 @@
 import type { Attachment } from "@/features/editor/hooks/useAttachments";
 import { getUploadUrl, uploadToS3, confirmUpload } from "../api/assetApi";
+import { resolveUploadMimeType } from "./fileValidation";
 
 /** 첨부 파일 업로드 결과 */
 export interface UploadAttachmentsResult {
@@ -45,15 +46,22 @@ export const uploadAttachments = async (
     }
 
     // 1. Presigned URL 발급
+    const mimeType = resolveUploadMimeType(file);
+    if (!mimeType) {
+      throw new Error(
+        `지원하지 않는 파일 형식입니다: ${file.name}`,
+      );
+    }
+
     const { result } = await getUploadUrl({
       noteId,
       fileName: file.name,
-      mimeType: file.type,
+      mimeType,
       fileSize: file.size,
     });
 
     // 2. S3 업로드
-    await uploadToS3(result.uploadUrl, file);
+    await uploadToS3(result.uploadUrl, file, mimeType);
 
     // 3. 서버 확정 (OCR 시작)
     await confirmUpload(result.assetId);

--- a/src/features/chat/components/leftpanel/StorageContent.tsx
+++ b/src/features/chat/components/leftpanel/StorageContent.tsx
@@ -8,13 +8,8 @@ import { NoteCard } from "@/features/storage/components/NoteCard";
 import { deleteAssets } from "@/features/assets/api/assetApi";
 import { useNoteDetail, noteKeys } from "@/features/notes/hooks/useNotes";
 import type { PanelTab } from "./types";
-import { useAuthStore } from "@/features/auth/store/auth_store";
 import { useStorageStore } from "@/features/storage/store/useStorageStore";
 import { assetKeys } from "@/features/storage/hooks/useAssets";
-import {
-  PLAN_DETAILS,
-  type PlanType,
-} from "@/features/subscription/types/plan_types";
 
 interface StorageFile {
   id: number;
@@ -24,6 +19,21 @@ interface StorageFile {
   mimeType?: string;
   ocrStatus?: "pending" | "processing" | "completed" | "failed";
 }
+
+const normalizeOcrStatus = (
+  status: string | undefined | null,
+): StorageFile["ocrStatus"] => {
+  const normalized = status?.toLowerCase();
+  if (
+    normalized === "pending" ||
+    normalized === "processing" ||
+    normalized === "completed" ||
+    normalized === "failed"
+  ) {
+    return normalized;
+  }
+  return "pending";
+};
 
 interface StorageContentProps {
   noteId: string;
@@ -51,14 +61,14 @@ export const StorageContent = ({
   const { data: noteDetail, refetch } = useNoteDetail(noteId, undefined, {
     refetchInterval: hasProcessingAssets ? 2000 : false, // 2초로 단축
   });
-  const { user } = useAuthStore();
 
   // OCR 처리 중인 에셋이 있으면 폴링 활성화
   useEffect(() => {
     const isProcessing =
       noteDetail?.assets?.some(
         (asset) =>
-          asset.ocrStatus === "pending" || asset.ocrStatus === "processing",
+          normalizeOcrStatus(asset.ocrStatus) === "pending" ||
+          normalizeOcrStatus(asset.ocrStatus) === "processing",
       ) ?? false;
     setHasProcessingAssets(isProcessing);
 
@@ -77,7 +87,7 @@ export const StorageContent = ({
       type: "upload",
       fileUrl: asset.thumbnailUrl ?? undefined,
       mimeType: getMimeType(asset.fileType), // fileType -> mimeType 변환 적용
-      ocrStatus: asset.ocrStatus as StorageFile["ocrStatus"],
+      ocrStatus: normalizeOcrStatus(asset.ocrStatus),
     }));
   }, [noteDetail]);
 
@@ -192,14 +202,8 @@ export const StorageContent = ({
     onTabChange("viewer");
   };
 
-  // 용량 계산 (MB 단위) -> 사용자 플랜에 따른 스토리지 한도 계산
-  const userPlan = (user?.plan as PlanType) || "Free";
-  const planStorageLimit = PLAN_DETAILS[userPlan]?.storage || "5GB";
-
-  // GB -> MB 변환
-  const totalLimitMB = planStorageLimit.includes("GB")
-    ? parseInt(planStorageLimit.replace("GB", "")) * 1024
-    : parseInt(planStorageLimit.replace("MB", "")) || 500;
+  // 노트별 용량 제한은 512MB 고정
+  const totalLimitMB = 512;
 
   const usedBytes =
     noteDetail?.assets?.reduce((acc, asset) => acc + asset.fileSize, 0) ?? 0;

--- a/src/features/editor/hooks/useEditorQueries.ts
+++ b/src/features/editor/hooks/useEditorQueries.ts
@@ -7,6 +7,7 @@ import {
   uploadCanvasImage,
 } from "../api/editor_api";
 import { getNoteDetail } from "@/features/notes/api/notes_api";
+import { noteKeys } from "@/features/notes/hooks/useNotes";
 import type {
   ToolDto,
   ChatAssetDto,
@@ -43,7 +44,7 @@ export const useTools = (query?: string) =>
  */
 export const useNoteAssets = (noteId: number | null, query?: string) =>
   useQuery<ChatAssetDto[], Error, ChatAssetDto[]>({
-    queryKey: ["noteAssets", noteId],
+    queryKey: [...noteKeys.detail(String(noteId ?? "")), "assets"],
     queryFn: async () => {
       if (!noteId) return [];
       const response = await getNoteDetail(noteId);

--- a/src/features/storage/hooks/useAssets.ts
+++ b/src/features/storage/hooks/useAssets.ts
@@ -9,6 +9,7 @@ import {
   getStorageUsage,
 } from "../api/assets_api";
 import type { UploadUrlRequest, StorageResponse } from "../api/assets_types";
+import { resolveUploadMimeType } from "@/features/assets/utils/fileValidation";
 
 // Query Keys
 export const assetKeys = {
@@ -41,7 +42,7 @@ export const useStorageInfo = (keyword?: string) => {
     staleTime: 1000 * 60 * 5, // 5분간 fresh 상태 유지
     gcTime: 1000 * 60 * 10, // 10분간 캐시 보관
     refetchOnWindowFocus: false, // 탭 이동 시 재요청 방지
-    refetchOnMount: false, // 마운트 시 캐시 우선 사용
+    refetchOnMount: "always", // 페이지 재진입 시 항상 최신 데이터 동기화
     retry: 2, // 실패 시 2회 재시도
   });
 };
@@ -69,6 +70,7 @@ export const useAssetDetail = (assetId: number, enabled = true) => {
 const uploadToS3 = async (
   uploadUrl: string,
   file: File,
+  contentType?: string,
   onProgress?: (progress: number) => void,
 ): Promise<void> => {
   return new Promise((resolve, reject) => {
@@ -95,7 +97,10 @@ const uploadToS3 = async (
     xhr.addEventListener("abort", () => reject(new Error("Upload aborted")));
 
     xhr.open("PUT", uploadUrl);
-    xhr.setRequestHeader("Content-Type", file.type);
+    xhr.setRequestHeader(
+      "Content-Type",
+      (contentType ?? file.type) || "application/octet-stream",
+    );
     xhr.send(file);
   });
 };
@@ -114,18 +119,23 @@ export const useUploadAsset = () => {
       file: File;
       onProgress?: (progress: number) => void;
     }) => {
+      const mimeType = resolveUploadMimeType(file);
+      if (!mimeType) {
+        throw new Error("지원하지 않는 파일 형식입니다.");
+      }
+
       // 1. presigned URL 발급
       const requestParams: UploadUrlRequest = {
         noteId,
         fileName: file.name,
-        mimeType: file.type,
+        mimeType,
         fileSize: file.size,
       };
       const urlResponse = await getUploadUrl(requestParams);
       const { uploadUrl, assetId } = urlResponse.result;
 
       // 2. S3에 직접 업로드
-      await uploadToS3(uploadUrl, file, onProgress);
+      await uploadToS3(uploadUrl, file, mimeType, onProgress);
 
       // 3. 업로드 완료 확인
       const confirmResponse = await confirmUpload(assetId);

--- a/src/features/storage/pages/StoragePage.tsx
+++ b/src/features/storage/pages/StoragePage.tsx
@@ -17,6 +17,17 @@ import { DeleteNotesModal } from "../components/DeleteNotesModal";
 import { DeletionSuccessModal } from "../components/DeletionSuccessModal";
 import { useStorageInfo } from "../hooks/useAssets";
 
+const getNearCapacityMessage = (planType?: string) => {
+  const normalized = (planType ?? "").toLowerCase();
+  if (normalized === "free") {
+    return "저장소가 거의 가득 찼습니다. Standard 플랜으로 업그레이드하세요!";
+  }
+  if (normalized === "standard") {
+    return "저장소가 거의 가득 찼습니다. Pro 플랜으로 업그레이드하세요!";
+  }
+  return "저장소가 거의 가득 찼습니다. 파일을 삭제하여 공간을 확보하세요!";
+};
+
 export const StoragePage = () => {
   const [keyword, setKeyword] = useState("");
   const [openNoteIds, setOpenNoteIds] = useState<number[]>([]);
@@ -38,6 +49,9 @@ export const StoragePage = () => {
   const handleSearch = (value: string) => {
     setKeyword(value);
   };
+
+  const showNearCapacityWarning = (data?.usagePercent ?? 0) >= 90;
+  const nearCapacityMessage = getNearCapacityMessage(data?.plan?.planType);
 
   return (
     <>
@@ -90,6 +104,14 @@ export const StoragePage = () => {
               <p className="text-gray-500">저장된 파일이 없습니다.</p>
             )}
           </div>
+
+          {showNearCapacityWarning && (
+            <div className="mt-6 flex justify-center">
+              <p className="font-['Pretendard'] text-[14px] font-medium text-[#FF3B30]">
+                {nearCapacityMessage}
+              </p>
+            </div>
+          )}
         </div>
       </div>
       {isDeleteModalOpen && <DeleteNotesModal />}

--- a/src/pages/hooks/useHomeSend.ts
+++ b/src/pages/hooks/useHomeSend.ts
@@ -1,10 +1,16 @@
 import { useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { useCreateNote, useNoteList } from "@/features/notes/hooks/useNotes";
+import {
+  useCreateNote,
+  useNoteList,
+  noteKeys,
+} from "@/features/notes/hooks/useNotes";
 import { useMyProfile } from "@/features/settings/hooks/useUser";
 import { getPlanMaxNotes } from "@/features/subscription/types/plan_types";
 import { useAuthStore } from "@/features/auth/store/auth_store";
 import { uploadAttachments } from "@/features/assets/utils/upload_attachments";
+import { resolveUploadMimeType } from "@/features/assets/utils/fileValidation";
 import {
   getUploadUrl,
   uploadToS3,
@@ -12,6 +18,7 @@ import {
 } from "@/features/assets/api/assetApi";
 import type { ChatSendData } from "@/features/editor/components/ChatInput";
 import type { MessageAttachment } from "@/features/chat/types/chat_types";
+import { assetKeys } from "@/features/storage/hooks/useAssets";
 
 /** ChatPage로 전달하는 첫 대화 데이터 (location.state) */
 export interface FirstMessageState {
@@ -42,6 +49,7 @@ export interface FirstMessageState {
  */
 export const useHomeSend = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { mutate: createNote, isPending: isCreatingNote } = useCreateNote();
   const { data: profile, isLoading: isProfileLoading } = useMyProfile();
   const authUser = useAuthStore((state) => state.user);
@@ -95,13 +103,17 @@ export const useHomeSend = () => {
             if (viewerFileRef.current) {
               const file = viewerFileRef.current;
               try {
+                const mimeType = resolveUploadMimeType(file);
+                if (!mimeType) {
+                  throw new Error("지원하지 않는 파일 형식");
+                }
                 const { result } = await getUploadUrl({
                   noteId: newNoteId,
                   fileName: file.name,
-                  mimeType: file.type,
+                  mimeType,
                   fileSize: file.size,
                 });
-                await uploadToS3(result.uploadUrl, file);
+                await uploadToS3(result.uploadUrl, file, mimeType);
                 await confirmUpload(result.assetId);
                 uploadedAssetId = result.assetId;
               } catch (error) {
@@ -135,6 +147,15 @@ export const useHomeSend = () => {
           }
 
           if (uploadFailed) return;
+
+          // 저장소/노트 캐시 즉시 무효화 (홈 업로드 후 저장소 페이지 동기화 지연 방지)
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: noteKeys.lists() }),
+            queryClient.invalidateQueries({
+              queryKey: noteKeys.detail(String(newNoteId)),
+            }),
+            queryClient.invalidateQueries({ queryKey: assetKeys.storage }),
+          ]);
 
           // 첨부파일 정보 → ChatPage 전달
           const attachmentInfos: MessageAttachment[] = data.attachments.map(


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #153 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 1) # 멘션 목록 즉시 반영
- detail 무효화/리패치 시 멘션 목록도 함께 갱신되도록 변경

### 2) 전체 용량 90% 이상 경고 메시지(플랜별 문구)
- Storage 페이지 하단에 사용량 90% 이상 시 경고 메시지 노출
  - Free → Standard 업그레이드 유도
  - Standard → Pro 업그레이드 유도
  - Pro → 파일 삭제로 공간 확보 유도

### 3) 노트 용량 512MB 고정 (좌측 Storage 패널)
- 채팅 좌측 Storage 패널의 노트 용량 계산을 플랜 기반에서 512MB 고정으로 변경

### 4) (기존 포함) Storage 동기화/표시 안정화
- 업로드/삭제 후 화면 간 반영 지연을 줄이기 위한 쿼리 갱신/정규화 보완(상태값 대소문자 방어 포함)

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 저장 공간이 90% 이상 찰 때 용량 경고 메시지 표시

* **버그 수정**
  * 파일 유형 감지 및 유효성 검사 개선
  * 지원하지 않는 파일 형식에 대한 명확한 오류 메시지 추가

* **개선 사항**
  * 파일 업로드 프로세스의 안정성 향상
  * 캐시 동기화 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->