### PR TITLE
Fix(#168): 채팅 첨부 이미지 previewUrl 무효화로 깨지는 문제 해결

### DIFF
--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -15,6 +15,8 @@ import { creditKeys } from "@/features/settings/hooks/useCredit";
 import { userKeys } from "@/features/settings/hooks/useUser";
 import { assetKeys } from "@/features/storage/hooks/useAssets";
 
+type PendingAttachment = ChatSendData["attachments"][number];
+
 /** 서버 ConversationInfo[] → ChatMessage[] 변환 */
 const convertConversations = (
   conversations: ConversationInfo[],
@@ -83,12 +85,45 @@ export const useChatMessages = () => {
   const [isFirstMessageSending, setIsFirstMessageSending] = useState(false);
   const [isStreamingResponse, setIsStreamingResponse] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const managedPreviewUrlsRef = useRef<Set<string>>(new Set());
   const isSending = isStreamingResponse || isUploading || isFirstMessageSending;
 
-  // 컴포넌트 언마운트 시 진행 중인 스트리밍 중단
+  const registerPreviewUrl = useCallback((url?: string) => {
+    if (url?.startsWith("blob:")) {
+      managedPreviewUrlsRef.current.add(url);
+    }
+  }, []);
+
+  const toMessageAttachment = useCallback(
+    (attachment: PendingAttachment): MessageAttachment => {
+      let previewUrl = attachment.previewUrl;
+
+      if (attachment.type === "canvas" && attachment.blob) {
+        previewUrl = URL.createObjectURL(attachment.blob);
+      } else if (attachment.mimeType.startsWith("image/") && attachment.file) {
+        previewUrl = URL.createObjectURL(attachment.file);
+      }
+
+      registerPreviewUrl(previewUrl);
+
+      return {
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        size: attachment.size,
+        previewUrl,
+      };
+    },
+    [registerPreviewUrl],
+  );
+
+  // 컴포넌트 언마운트 시 진행 중인 스트리밍 + 미리보기 URL 정리
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort();
+      managedPreviewUrlsRef.current.forEach((url) => {
+        URL.revokeObjectURL(url);
+      });
+      managedPreviewUrlsRef.current.clear();
     };
   }, []);
 
@@ -203,7 +238,10 @@ export const useChatMessages = () => {
 
     const attachments: MessageAttachment[] | undefined =
       firstMessageData.attachments.length > 0
-        ? firstMessageData.attachments
+        ? firstMessageData.attachments.map((attachment) => {
+            registerPreviewUrl(attachment.previewUrl);
+            return attachment;
+          })
         : undefined;
 
     const tempUserMsgId = `temp-first-${Date.now()}`;
@@ -291,7 +329,7 @@ export const useChatMessages = () => {
     };
 
     sendFirst();
-  }, [firstMessageData, noteId, processStream, queryClient]);
+  }, [firstMessageData, noteId, processStream, queryClient, registerPreviewUrl]);
 
   // ─── 후속 대화 전송 핸들러 ───
   const handleSend = useCallback(
@@ -338,12 +376,7 @@ export const useChatMessages = () => {
       // 3. 첨부 정보
       const messageAttachments: MessageAttachment[] | undefined =
         data.attachments.length > 0
-          ? data.attachments.map((a) => ({
-              name: a.name,
-              mimeType: a.mimeType,
-              size: a.size,
-              previewUrl: a.previewUrl,
-            }))
+          ? data.attachments.map(toMessageAttachment)
           : undefined;
 
       // 4. 낙관적 UI + SSE 스트리밍 API 호출
@@ -421,7 +454,7 @@ export const useChatMessages = () => {
         setIsStreamingResponse(false);
       }
     },
-    [noteId, processStream, queryClient],
+    [noteId, processStream, queryClient, toMessageAttachment],
   );
 
   // ─── 파생 데이터 ───

--- a/src/pages/hooks/useHomeSend.ts
+++ b/src/pages/hooks/useHomeSend.ts
@@ -20,6 +20,18 @@ import type { ChatSendData } from "@/features/editor/components/ChatInput";
 import type { MessageAttachment } from "@/features/chat/types/chat_types";
 import { assetKeys } from "@/features/storage/hooks/useAssets";
 
+const createPersistentPreviewUrl = (
+  attachment: ChatSendData["attachments"][number],
+): string | undefined => {
+  if (attachment.type === "canvas" && attachment.blob) {
+    return URL.createObjectURL(attachment.blob);
+  }
+  if (attachment.mimeType.startsWith("image/") && attachment.file) {
+    return URL.createObjectURL(attachment.file);
+  }
+  return attachment.previewUrl;
+};
+
 /** ChatPage로 전달하는 첫 대화 데이터 (location.state) */
 export interface FirstMessageState {
   /** 사용자 질문/지시문 (ConversationRequest.text) */
@@ -163,7 +175,7 @@ export const useHomeSend = () => {
               name: a.name,
               mimeType: a.mimeType,
               size: a.size,
-              previewUrl: a.previewUrl,
+              previewUrl: createPersistentPreviewUrl(a),
             }),
           );
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #168'

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### 원인
- 채팅 버블 이미지는 서버 URL이 아니라 `attachment.previewUrl(blob:)`을 그대로 `<img src>`로 사용
- 그런데 전송 직후 blob URL을 `URL.revokeObjectURL()`로 무효화하거나,
  `clearAttachments()` 호출로 previewUrl 참조가 끊기면서 채팅에서 이미지가 깨짐
  - `ChatInput.tsx:169`
  - `useAttachments.ts:82`
  - `useAttachments.ts:119`
  - 깨진 경우 alt 텍스트가 표시됨: `MessageAttachments.tsx:17`

### 해결
1) **Home -> Chat 첫 메시지 전달 시**
- 채팅 메시지용 previewUrl을 새로 생성해 전달하도록 변경
  - `useHomeSend.ts:23`
  - `useHomeSend.ts:172`

2) **ChatPage 후속 전송에서도**
- 채팅 메시지용 blob URL을 별도로 생성하도록 변경
  - `useChatMessages.ts:97`
  - `useChatMessages.ts:377`

3) **blob URL 수명 관리**
- 채팅에서 생성한 blob URL을 `Set`으로 추적
- ChatPage 언마운트 시 일괄 revoke하여 누수 방지
  - `useChatMessages.ts:88`
  - `useChatMessages.ts:119`

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 채팅에서 첨부파일 미리보기 관리 및 처리를 개선했습니다.
  * 임시 미리보기 파일의 정리 프로세스를 최적화하여 리소스 사용을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->