### PR TITLE
Feat(#173): 채팅 히스토리 불러오기 로직 수정

### DIFF
--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -55,13 +55,83 @@ export const useChatMessages = () => {
   const firstMessageData = initialStateRef.current?.firstMessage as
     | FirstMessageState
     | undefined;
+  const chatEntrySource =
+    (initialStateRef.current as { chatEntrySource?: string } | null)
+      ?.chatEntrySource ?? "unknown";
 
   const viewerFile = firstMessageData?.viewerFile;
 
   const hasFirstMessage = !!firstMessageData;
 
   // ─── 노트 상세 로드 (제목·메타데이터 + 재진입 시 히스토리) ───
-  const { data: noteDetail, isLoading: isNoteLoading } = useNoteDetail(noteId);
+  const {
+    data: noteDetail,
+    isLoading: isNoteLoading,
+    isError: isNoteDetailError,
+    error: noteDetailError,
+  } = useNoteDetail(
+    noteId,
+    {
+      conversationPage: 0,
+      conversationSize: 50,
+    },
+    {
+      fetchAllConversations: true,
+      refetchOnMount: "always",
+    },
+  );
+
+  useEffect(() => {
+    if (!noteId) return;
+    console.info("[ChatHistory] 채팅방 진입", {
+      noteId,
+      source: chatEntrySource,
+      hasFirstMessage,
+    });
+  }, [noteId, chatEntrySource, hasFirstMessage]);
+
+  useEffect(() => {
+    if (!noteId || hasFirstMessage || isNoteLoading) return;
+
+    if (isNoteDetailError) {
+      console.error("[ChatHistory] 노트 상세 조회 실패", {
+        noteId,
+        source: chatEntrySource,
+        error: noteDetailError,
+      });
+      return;
+    }
+
+    if (!noteDetail) return;
+
+    const conversationCount = noteDetail.conversations?.length ?? 0;
+    const pageInfo = noteDetail.conversationPageInfo;
+
+    if (conversationCount === 0) {
+      console.error("[ChatHistory] 노트 상세 조회 성공했지만 대화가 비어있음", {
+        noteId,
+        source: chatEntrySource,
+        conversationCount,
+        pageInfo,
+      });
+      return;
+    }
+
+    console.info("[ChatHistory] 대화 히스토리 로드 성공", {
+      noteId,
+      source: chatEntrySource,
+      conversationCount,
+      pageInfo,
+    });
+  }, [
+    noteId,
+    hasFirstMessage,
+    isNoteLoading,
+    isNoteDetailError,
+    noteDetailError,
+    noteDetail,
+    chatEntrySource,
+  ]);
 
   // ─── 메시지 상태 ───
   const [messages, setMessages] = useState<ChatMessage[]>([]);

--- a/src/features/notes/api/notes_api.ts
+++ b/src/features/notes/api/notes_api.ts
@@ -83,6 +83,57 @@ export const getNoteDetail = async (
   return response.data;
 };
 
+export const getNoteDetailWithAllConversations = async (
+  noteId: number,
+  params?: NoteDetailParams,
+): Promise<ApiResponse<NoteDetailResponse>> => {
+  const pageSize = params?.conversationSize ?? 50;
+  const firstResponse = await getNoteDetail(noteId, {
+    ...params,
+    conversationPage: 0,
+    conversationSize: pageSize,
+  });
+
+  const firstResult = firstResponse.result;
+  if (!firstResult.conversationPageInfo?.hasNext) {
+    return firstResponse;
+  }
+
+  let currentPage = firstResult.conversationPageInfo.page;
+  let hasNext: boolean = firstResult.conversationPageInfo.hasNext;
+  let mergedConversations = [...firstResult.conversations];
+  let lastPageInfo = firstResult.conversationPageInfo;
+
+  while (hasNext) {
+    const nextPage = currentPage + 1;
+    const pageResponse = await getNoteDetail(noteId, {
+      ...params,
+      conversationPage: nextPage,
+      conversationSize: pageSize,
+    });
+
+    mergedConversations = [
+      ...mergedConversations,
+      ...pageResponse.result.conversations,
+    ];
+    lastPageInfo = pageResponse.result.conversationPageInfo;
+    currentPage = nextPage;
+    hasNext = pageResponse.result.conversationPageInfo.hasNext;
+  }
+
+  return {
+    ...firstResponse,
+    result: {
+      ...firstResult,
+      conversations: mergedConversations,
+      conversationPageInfo: {
+        ...lastPageInfo,
+        hasNext: false,
+      },
+    },
+  };
+};
+
 // 노트 벌크 삭제
 export const deleteNotesBulk = async (
   noteIds: number[],

--- a/src/features/notes/components/NoteCard.tsx
+++ b/src/features/notes/components/NoteCard.tsx
@@ -114,7 +114,9 @@ export const NoteCard = ({
       return;
     }
 
-    navigate(`/app/chat/${note.noteId}`);
+    navigate(`/app/chat/${note.noteId}`, {
+      state: { chatEntrySource: "notes-page-card" },
+    });
   };
 
   const handleCardKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {

--- a/src/features/notes/hooks/useNotes.ts
+++ b/src/features/notes/hooks/useNotes.ts
@@ -8,6 +8,7 @@ import {
   getNoteList,
   createNote,
   getNoteDetail,
+  getNoteDetailWithAllConversations,
   updateNoteTitle,
   deleteNotesBulk,
   deleteNote,
@@ -23,7 +24,8 @@ export const noteKeys = {
   all: ["notes"] as const,
   lists: () => [...noteKeys.all, "list"] as const,
   list: (params?: NoteListParams) => [...noteKeys.lists(), params] as const,
-  detail: (id: string) => [...noteKeys.all, "detail", id] as const,
+  detail: (id: string, params?: NoteDetailParams) =>
+    [...noteKeys.all, "detail", id, params] as const,
 };
 
 // 노트 목록 조회 Hook (일반 페이지네이션)
@@ -103,17 +105,25 @@ export const useUpdateNoteTitle = () => {
 export const useNoteDetail = (
   noteId: string | undefined,
   params?: NoteDetailParams,
-  options?: { enabled?: boolean; refetchInterval?: number | false },
+  options?: {
+    enabled?: boolean;
+    refetchInterval?: number | false;
+    fetchAllConversations?: boolean;
+    refetchOnMount?: boolean | "always";
+  },
 ) => {
   return useQuery({
-    queryKey: noteKeys.detail(noteId ?? ""),
+    queryKey: noteKeys.detail(noteId ?? "", params),
     queryFn: async () => {
-      const response = await getNoteDetail(Number(noteId), params);
+      const response = options?.fetchAllConversations
+        ? await getNoteDetailWithAllConversations(Number(noteId), params)
+        : await getNoteDetail(Number(noteId), params);
       return response.result;
     },
     enabled: (options?.enabled ?? true) && !!noteId,
     staleTime: 1000 * 60 * 1, // 1분
     refetchInterval: options?.refetchInterval,
+    refetchOnMount: options?.refetchOnMount,
   });
 };
 

--- a/src/features/search/components/SearchModal.tsx
+++ b/src/features/search/components/SearchModal.tsx
@@ -134,9 +134,11 @@ const SearchModal = ({ isOpen, onClose }: SearchModalProps) => {
 
   // 결과 클릭 → 해당 노트 채팅방으로 이동
   const handleResultClick = useCallback(
-    (noteId: number) => {
+    (noteId: number, source: "search-modal-search" | "search-modal-recent") => {
       onClose();
-      navigate(`/app/chat/${noteId}`);
+      navigate(`/app/chat/${noteId}`, {
+        state: { chatEntrySource: source },
+      });
     },
     [navigate, onClose],
   );
@@ -211,7 +213,9 @@ const SearchModal = ({ isOpen, onClose }: SearchModalProps) => {
                     key={section.date}
                     dateLabel={section.date}
                     items={section.chats}
-                    onItemClick={handleResultClick}
+                    onItemClick={(noteId) =>
+                      handleResultClick(noteId, "search-modal-search")
+                    }
                     searchQuery={debouncedQuery}
                   />
                 ))}
@@ -232,7 +236,9 @@ const SearchModal = ({ isOpen, onClose }: SearchModalProps) => {
                 key={section.date}
                 dateLabel={section.date}
                 items={section.chats}
-                onItemClick={handleResultClick}
+                onItemClick={(noteId) =>
+                  handleResultClick(noteId, "search-modal-recent")
+                }
               />
             ))
           ) : (

--- a/src/features/sidebar/components/RecentNotes.tsx
+++ b/src/features/sidebar/components/RecentNotes.tsx
@@ -121,6 +121,7 @@ const RecentNoteItem = ({ note }: { note: RecentNote }) => {
     <li>
       <NavLink
         to={`/app/chat/${note.id}`}
+        state={{ chatEntrySource: "sidebar-recent-notes" }}
         className={({ isActive }) =>
           `block truncate rounded-lg py-[6px] pl-[12px] text-[14px] leading-[160%] font-bold tracking-[-0.05em] text-[#454545] transition-colors ${
             isActive ? "mr-[-6px] bg-[#EBEBEB]" : "hover:bg-[#F5F5F5]"


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #173 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 전체 대화 히스토리 로딩 추가
  -` hasNext=false` 까지 순회하여 `conversations` 병합
- 채팅 진입 시 히스토리 재조회 강제
- 진입 경로 추적 및 디버깅 로그 추가



## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 노트 상세 조회 시 전체 대화 기록을 통합하여 한 번에 로드하는 기능 추가
  * 검색, 최근 노트, 사이드바 등 다양한 진입점에서 채팅으로 이동할 때 사용자 경로 정보 추가로 분석 데이터 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->