### PR TITLE
Feat(#193): 채팅 히스토리에서 빈 assistant 메시지 폴백 처리

### DIFF
--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -21,18 +21,38 @@ type PendingAttachment = ChatSendData["attachments"][number];
 const convertConversations = (
   conversations: ConversationInfo[],
 ): ChatMessage[] =>
-  conversations.flatMap((conv) => [
-    {
+  conversations.flatMap((conv) => {
+    const messages: ChatMessage[] = [];
+
+    // 사용자 메시지
+    messages.push({
       id: `msg-${conv.userMessage.messageId}`,
       role: "user" as const,
       content: conv.userMessage.content,
-    },
-    {
-      id: `msg-${conv.assistantMessage.messageId}`,
-      role: "assistant" as const,
-      content: conv.assistantMessage.content,
-    },
-  ]);
+    });
+
+    // AI 메시지 (빈 내용이면 건너뛰기)
+    const assistantContent = conv.assistantMessage.content || "";
+    if (assistantContent.trim()) {
+      messages.push({
+        id: `msg-${conv.assistantMessage.messageId}`,
+        role: "assistant" as const,
+        content: assistantContent,
+      });
+    } else {
+      // 빈 응답인 경우 에러 메시지 표시
+      console.warn(
+        `[ChatHistory] Assistant 메시지가 비어있음 - messageId: ${conv.assistantMessage.messageId}`,
+      );
+      messages.push({
+        id: `msg-${conv.assistantMessage.messageId}`,
+        role: "assistant" as const,
+        content: "응답을 불러올 수 없습니다. 새로고침 후 다시 시도해주세요.",
+      });
+    }
+
+    return messages;
+  });
 
 /**
  * 채팅 메시지 상태 관리 훅


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #193 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 채팅 히스토리 변환 로직에서 assistant 메시지가 null/빈 문자열이면 폴백 문구로 대체
- 빈 assistant 감지 시 console.warn으로 messageId 로그 출력 (디버깅 보조)

## 📸 스크린샷



## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 채팅 어시스턴트의 빈 응답 처리 개선. 이제 빈 응답이 감지되면 사용자 친화적인 오류 메시지가 표시되어 더 나은 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->