### PR TITLE
Fix(#198): 홈->노트 딜레이 해결, 파일첨부 및 크레딧 차감 백그라운드 처리

### DIFF
--- a/src/features/chat/components/rightpanel/RightPanel.tsx
+++ b/src/features/chat/components/rightpanel/RightPanel.tsx
@@ -7,7 +7,7 @@ import { LoadingSpinner } from "@/shared/components/loading-spinner";
 interface RightPanelProps {
   messages: ChatMessage[];
   noteId?: number | null;
-  onSend?: (data: ChatSendData) => void;
+  onSend?: (data: ChatSendData) => void | boolean | Promise<void | boolean>;
   isSending?: boolean;
   /** 대화 히스토리 로딩 중 여부 */
   isLoading?: boolean;

--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -1,12 +1,18 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useLocation, useParams } from "react-router-dom";
+import { useLocation, useParams, useSearchParams } from "react-router-dom";
 import {
   createConversation as createConversationApi,
   parseSSEStream,
 } from "@/features/editor/api/editor_api";
 import { useNoteDetail, noteKeys } from "@/features/notes/hooks/useNotes";
 import { uploadAttachments } from "@/features/assets/utils/upload_attachments";
+import {
+  getUploadUrl,
+  uploadToS3,
+  confirmUpload,
+} from "@/features/assets/api/assetApi";
+import { resolveUploadMimeType } from "@/features/assets/utils/fileValidation";
 import type { ChatSendData } from "@/features/editor/components/ChatInput";
 import type { ConversationInfo } from "@/features/notes/api/notes_types";
 import type { FirstMessageState } from "@/pages/hooks/useHomeSend";
@@ -65,6 +71,7 @@ const convertConversations = (
 export const useChatMessages = () => {
   const { noteId } = useParams<{ noteId: string }>();
   const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
 
   // ─── location.state에서 초기 데이터 추출 (ref로 보존) ───
@@ -361,28 +368,77 @@ export const useChatMessages = () => {
       const signal = abortControllerRef.current!.signal;
 
       try {
+        let uploadedViewerAssetId: number | undefined;
+        let uploadedFileAssetIds: number[] = [];
+        let uploadedCanvasImageIds: number[] = [];
+
+        if (firstMessageData.pendingViewerFile) {
+          const file = firstMessageData.pendingViewerFile;
+          const mimeType = resolveUploadMimeType(file);
+          if (!mimeType) {
+            throw new Error("지원하지 않는 뷰어 파일 형식입니다.");
+          }
+
+          const { result } = await getUploadUrl({
+            noteId: Number(noteId),
+            fileName: file.name,
+            mimeType,
+            fileSize: file.size,
+          });
+
+          await uploadToS3(result.uploadUrl, file, mimeType);
+          await confirmUpload(result.assetId);
+          uploadedViewerAssetId = result.assetId;
+        }
+
+        if (firstMessageData.pendingAttachments?.length) {
+          setIsUploading(true);
+          const uploadResult = await uploadAttachments(
+            Number(noteId),
+            firstMessageData.pendingAttachments,
+          );
+          uploadedFileAssetIds = uploadResult.fileAssetIds;
+          uploadedCanvasImageIds = uploadResult.canvasAssetIds;
+          setIsUploading(false);
+        }
+
         const response = await createConversationApi(
           {
             noteId: Number(noteId),
             text: firstMessageData.text,
             latex: firstMessageData.latex,
             mentionedAssetIds:
-              firstMessageData.mentionedAssetIds.length > 0
-                ? firstMessageData.mentionedAssetIds
+              [...firstMessageData.mentionedAssetIds, ...uploadedFileAssetIds]
+                .length > 0
+                ? [
+                    ...firstMessageData.mentionedAssetIds,
+                    ...uploadedFileAssetIds,
+                  ]
                 : undefined,
             chosenFeatures:
               firstMessageData.chosenFeatures.length > 0
                 ? firstMessageData.chosenFeatures
                 : undefined,
             canvasImageIds:
-              firstMessageData.canvasImageIds.length > 0
-                ? firstMessageData.canvasImageIds
+              [...firstMessageData.canvasImageIds, ...uploadedCanvasImageIds]
+                .length > 0
+                ? [
+                    ...firstMessageData.canvasImageIds,
+                    ...uploadedCanvasImageIds,
+                  ]
                 : undefined,
           },
           { isStream: true, signal },
         );
 
         await processStream(response, tempAssistantMsgId, signal);
+
+        if (uploadedViewerAssetId) {
+          const nextSearchParams = new URLSearchParams(searchParams);
+          nextSearchParams.set("panel", "viewer");
+          nextSearchParams.set("file", String(uploadedViewerAssetId));
+          setSearchParams(nextSearchParams, { replace: true });
+        }
 
         // 첫 대화 성공 후 노트 상세 refetch → AI가 갱신한 제목 반영
         queryClient.invalidateQueries({
@@ -391,6 +447,10 @@ export const useChatMessages = () => {
         // 크레딧 잔액 최신화 (대화 생성 시 서버에서 자동 차감)
         queryClient.invalidateQueries({ queryKey: creditKeys.all });
         queryClient.invalidateQueries({ queryKey: userKeys.profile() });
+        queryClient.invalidateQueries({
+          queryKey: noteKeys.detail(String(noteId)),
+        });
+        queryClient.invalidateQueries({ queryKey: assetKeys.storage });
       } catch (error) {
         if (signal.aborted) return;
         console.error("첫 대화 생성 실패:", error);
@@ -414,6 +474,7 @@ export const useChatMessages = () => {
           ];
         });
       } finally {
+        setIsUploading(false);
         setIsFirstMessageSending(false);
       }
     };
@@ -425,6 +486,8 @@ export const useChatMessages = () => {
     processStream,
     queryClient,
     registerPreviewUrl,
+    searchParams,
+    setSearchParams,
   ]);
 
   // ─── 후속 대화 전송 핸들러 ───

--- a/src/features/editor/components/ChatInput.tsx
+++ b/src/features/editor/components/ChatInput.tsx
@@ -52,7 +52,7 @@ interface ChatInputProps {
   /** 현재 노트 ID (#파일 멘션에 사용) */
   noteId?: number | null;
   /** 메시지 전송 콜백 */
-  onSend?: (data: ChatSendData) => void;
+  onSend?: (data: ChatSendData) => void | boolean | Promise<void | boolean>;
   /** 전송 중 여부 (true이면 전송 버튼 비활성화) */
   isSending?: boolean;
 }
@@ -149,8 +149,6 @@ export const ChatInput = ({
     if (isSending || isProcessing) return;
     if (!hasContent && attachments.length === 0) return;
 
-    setIsProcessing(true);
-
     // DOM에서 콘텐츠 추출 (텍스트 + LaTeX + 멘션)
     const extracted = inputRef.current
       ? extractInputContent(inputRef.current)
@@ -158,14 +156,64 @@ export const ChatInput = ({
 
     if (!extracted.text && attachments.length === 0) return;
 
+    setIsProcessing(true);
+
+    const creditPayload = {
+      eventType: "LLM_QUERY" as const,
+      difficulty: "medium" as const,
+      featureName: "Chat",
+      description: "AI 채팅 질문",
+    };
+
+    const mentionedToolCodes = selectedToolCode ? [selectedToolCode] : [];
+    const sendPayload: ChatSendData = {
+      message: extracted.text,
+      latex: extracted.latex,
+      mentionedAssetIds: extracted.mentionedAssetIds,
+      mentionedToolCodes,
+      attachments: [...attachments],
+    };
+
+    const resetInputState = () => {
+      if (inputRef.current) {
+        inputRef.current.innerHTML = "";
+      }
+      setHasContent(false);
+      clearMentionedAssets();
+      clearAttachments();
+      handleToolSelect(""); // 선택된 도구 초기화
+    };
+
+    const isHomeSend = noteId == null;
+
+    // 홈에서는 이동을 막지 않도록 먼저 전송(onSend) 후 크레딧 차감은 백그라운드 처리
+    if (isHomeSend) {
+      try {
+        const sendResult = await onSend?.(sendPayload);
+
+        if (sendResult === false) {
+          setIsProcessing(false);
+          return;
+        }
+
+        resetInputState();
+
+        void deductCredit(creditPayload).then((creditResponse) => {
+          if (!creditResponse.result.success) {
+            console.warn("[HomeSend] 크레딧 차감 실패", creditResponse.result);
+          }
+        });
+      } catch (error) {
+        console.error("Home send failed:", error);
+      } finally {
+        setIsProcessing(false);
+      }
+      return;
+    }
+
     // 크레딧 차감 시도
     try {
-      const creditResponse = await deductCredit({
-        eventType: "LLM_QUERY",
-        difficulty: "medium",
-        featureName: "Chat",
-        description: "AI 채팅 질문",
-      });
+      const creditResponse = await deductCredit(creditPayload);
 
       if (!creditResponse.result.success) {
         setShowCreditModal(true);
@@ -180,26 +228,9 @@ export const ChatInput = ({
     }
 
     try {
-      // 도구 코드 수집
-      const mentionedToolCodes = selectedToolCode ? [selectedToolCode] : [];
-
       // 부모 콜백 호출
-      onSend?.({
-        message: extracted.text,
-        latex: extracted.latex,
-        mentionedAssetIds: extracted.mentionedAssetIds,
-        mentionedToolCodes,
-        attachments: [...attachments],
-      });
-
-      // 입력 상태 초기화
-      if (inputRef.current) {
-        inputRef.current.innerHTML = "";
-      }
-      setHasContent(false);
-      clearMentionedAssets();
-      clearAttachments();
-      handleToolSelect(""); // 선택된 도구 초기화
+      onSend?.(sendPayload);
+      resetInputState();
     } finally {
       setIsProcessing(false);
     }

--- a/src/features/editor/components/ChatInput.tsx
+++ b/src/features/editor/components/ChatInput.tsx
@@ -188,21 +188,34 @@ export const ChatInput = ({
 
     // 홈에서는 이동을 막지 않도록 먼저 전송(onSend) 후 크레딧 차감은 백그라운드 처리
     if (isHomeSend) {
-      try {
-        const sendResult = await onSend?.(sendPayload);
+      if (!onSend) {
+        console.error("[HomeSend] onSend 콜백이 없어 전송을 중단합니다.");
+        setIsProcessing(false);
+        return;
+      }
 
-        if (sendResult === false) {
+      try {
+        const sendResult = await onSend(sendPayload);
+
+        if (sendResult !== true) {
           setIsProcessing(false);
           return;
         }
 
         resetInputState();
 
-        void deductCredit(creditPayload).then((creditResponse) => {
-          if (!creditResponse.result.success) {
-            console.warn("[HomeSend] 크레딧 차감 실패", creditResponse.result);
-          }
-        });
+        void deductCredit(creditPayload)
+          .then((creditResponse) => {
+            if (!creditResponse.result.success) {
+              console.warn(
+                "[HomeSend] 크레딧 차감 실패",
+                creditResponse.result,
+              );
+            }
+          })
+          .catch((error) => {
+            console.error("[HomeSend] 크레딧 차감 요청 실패:", error);
+          });
       } catch (error) {
         console.error("Home send failed:", error);
       } finally {

--- a/src/features/editor/components/ChatInput.tsx
+++ b/src/features/editor/components/ChatInput.tsx
@@ -218,6 +218,7 @@ export const ChatInput = ({
           });
       } catch (error) {
         console.error("Home send failed:", error);
+        alert("전송 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
       } finally {
         setIsProcessing(false);
       }
@@ -242,8 +243,11 @@ export const ChatInput = ({
 
     try {
       // 부모 콜백 호출
-      onSend?.(sendPayload);
+      await onSend?.(sendPayload);
       resetInputState();
+    } catch (error) {
+      console.error("Send failed:", error);
+      alert("메시지 전송 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
     } finally {
       setIsProcessing(false);
     }

--- a/src/features/settings/hooks/useCredit.ts
+++ b/src/features/settings/hooks/useCredit.ts
@@ -1,6 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getCreditHistory, useCredit } from "../api/credit_api";
-import type { GetCreditHistoryParams } from "../api/credit_types";
+import type {
+  CreditUsageRequest,
+  GetCreditHistoryParams,
+} from "../api/credit_types";
 import { tokenUtils } from "@/shared/api/client";
 import { userKeys } from "./useUser";
 
@@ -29,6 +32,52 @@ export const useUseCredit = () => {
 
   return useMutation({
     mutationFn: useCredit,
+    onMutate: async (variables: CreditUsageRequest) => {
+      await queryClient.cancelQueries({ queryKey: userKeys.profile() });
+
+      const previousProfile = queryClient.getQueryData<MyProfileResponse>(
+        userKeys.profile(),
+      );
+
+      if (!previousProfile) {
+        return { previousProfile };
+      }
+
+      const optimisticAmount = Math.max(variables.amount ?? 15, 0);
+
+      const currentDaily = previousProfile.credit.dailyCredit.balance;
+      const currentMonthly = previousProfile.credit.monthlyCredit.balance;
+
+      const nextDaily = Math.max(currentDaily - optimisticAmount, 0);
+      const remainingAmount = Math.max(optimisticAmount - currentDaily, 0);
+      const nextMonthly = Math.max(currentMonthly - remainingAmount, 0);
+
+      queryClient.setQueryData<MyProfileResponse>(userKeys.profile(), {
+        ...previousProfile,
+        credit: {
+          ...previousProfile.credit,
+          dailyCredit: {
+            ...previousProfile.credit.dailyCredit,
+            balance: nextDaily,
+          },
+          monthlyCredit: {
+            ...previousProfile.credit.monthlyCredit,
+            balance: nextMonthly,
+          },
+          totalAvailable: Math.max(
+            previousProfile.credit.totalAvailable - optimisticAmount,
+            0,
+          ),
+        },
+      });
+
+      return { previousProfile };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousProfile) {
+        queryClient.setQueryData(userKeys.profile(), context.previousProfile);
+      }
+    },
     onSuccess: (data) => {
       if (data.result.success) {
         const newBalance = data.result.balance;

--- a/src/pages/hooks/useHomeSend.ts
+++ b/src/pages/hooks/useHomeSend.ts
@@ -9,13 +9,6 @@ import {
 import { useMyProfile } from "@/features/settings/hooks/useUser";
 import { getPlanMaxNotes } from "@/features/subscription/types/plan_types";
 import { useAuthStore } from "@/features/auth/store/auth_store";
-import { uploadAttachments } from "@/features/assets/utils/upload_attachments";
-import { resolveUploadMimeType } from "@/features/assets/utils/fileValidation";
-import {
-  getUploadUrl,
-  uploadToS3,
-  confirmUpload,
-} from "@/features/assets/api/assetApi";
 import type { ChatSendData } from "@/features/editor/components/ChatInput";
 import type { MessageAttachment } from "@/features/chat/types/chat_types";
 import { assetKeys } from "@/features/storage/hooks/useAssets";
@@ -46,17 +39,20 @@ export interface FirstMessageState {
   canvasImageIds: number[];
   /** 첨부 파일 정보 (UI 표시용, API 필드 아님) */
   attachments: MessageAttachment[];
+  /** 업로드 전 원본 첨부 데이터 (채팅방 진입 후 백그라운드 업로드용) */
+  pendingAttachments?: ChatSendData["attachments"];
   /** 뷰어 파일 정보 (좌측 패널 표시용, API 필드 아님) */
   viewerFile?: { name: string; mimeType: string; size: number };
+  /** 업로드 전 뷰어 파일 (채팅방 진입 후 백그라운드 업로드용) */
+  pendingViewerFile?: File;
 }
 
 /**
  * HomePage 전송 로직 훅
  *
  * 1. 노트 생성 (POST /api/notes — 노트 리소스만 생성)
- * 2. 뷰어 파일 업로드 (presigned → S3 → confirm)
- * 3. ChatInput 첨부파일 업로드
- * 4. ChatPage로 네비게이션 (첫 메시지 데이터를 state로 전달)
+ * 2. ChatPage로 즉시 네비게이션 (첫 메시지 데이터 + 업로드 대기 데이터 전달)
+ * 3. 실제 첨부 업로드/첫 대화 전송은 ChatPage에서 백그라운드 처리
  *    → ChatPage에서 POST /api/conversations 호출하여 AI 응답 수신
  */
 export const useHomeSend = () => {
@@ -69,17 +65,16 @@ export const useHomeSend = () => {
     page: 0,
     size: 1,
   });
-  const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   /** 뷰어용 File 객체 참조 (노트 생성 후 업로드) */
   const viewerFileRef = useRef<File | null>(null);
 
-  const isSending = isCreatingNote || isUploading;
+  const isSending = isCreatingNote;
 
   const clearError = () => setUploadError(null);
 
-  const handleSend = (data: ChatSendData) => {
+  const handleSend = (data: ChatSendData): boolean => {
     const totalNotes = noteListData?.pageInfo.totalElements ?? 0;
     const resolvedPlan = profile?.subscription?.plan ?? authUser?.plan;
     const shouldCheckLimit = !isProfileLoading || !!resolvedPlan;
@@ -91,7 +86,7 @@ export const useHomeSend = () => {
         setUploadError(
           "노트 생성 개수가 초과하였습니다. 플랜을 업그레이드 해주세요.",
         );
-        return;
+        return false;
       }
     }
 
@@ -99,75 +94,9 @@ export const useHomeSend = () => {
     createNote(
       {},
       {
-        onSuccess: async (response) => {
+        onSuccess: (response) => {
           const newNoteId = response.result.noteId;
-          setIsUploading(true);
-
-          let uploadFailed = false;
-          let uploadedAssetId: number | undefined;
           setUploadError(null);
-          let uploadedCanvasImageIds: number[] = [];
-          let uploadedFileAssetIds: number[] = [];
-
-          try {
-            // 1. 뷰어 파일 업로드
-
-            if (viewerFileRef.current) {
-              const file = viewerFileRef.current;
-              try {
-                const mimeType = resolveUploadMimeType(file);
-                if (!mimeType) {
-                  throw new Error("지원하지 않는 파일 형식");
-                }
-                const { result } = await getUploadUrl({
-                  noteId: newNoteId,
-                  fileName: file.name,
-                  mimeType,
-                  fileSize: file.size,
-                });
-                await uploadToS3(result.uploadUrl, file, mimeType);
-                await confirmUpload(result.assetId);
-                uploadedAssetId = result.assetId;
-              } catch (error) {
-                console.error("[HomePage] 뷰어 파일 업로드 실패:", error);
-                setUploadError(
-                  "파일 업로드에 실패했습니다. 다시 시도해주세요.",
-                );
-                uploadFailed = true;
-              }
-            }
-
-            // 2. ChatInput 첨부 파일 업로드
-            if (!uploadFailed && data.attachments.length > 0) {
-              try {
-                const uploadResult = await uploadAttachments(
-                  newNoteId,
-                  data.attachments,
-                );
-                uploadedFileAssetIds = uploadResult.fileAssetIds;
-                uploadedCanvasImageIds = uploadResult.canvasAssetIds;
-              } catch (error) {
-                console.error("[HomePage] 첨부 파일 업로드 실패:", error);
-                setUploadError(
-                  "첨부 파일 업로드에 실패했습니다. 다시 시도해주세요.",
-                );
-                uploadFailed = true;
-              }
-            }
-          } finally {
-            setIsUploading(false);
-          }
-
-          if (uploadFailed) return;
-
-          // 저장소/노트 캐시 즉시 무효화 (홈 업로드 후 저장소 페이지 동기화 지연 방지)
-          await Promise.all([
-            queryClient.invalidateQueries({ queryKey: noteKeys.lists() }),
-            queryClient.invalidateQueries({
-              queryKey: noteKeys.detail(String(newNoteId)),
-            }),
-            queryClient.invalidateQueries({ queryKey: assetKeys.storage }),
-          ]);
 
           // 첨부파일 정보 → ChatPage 전달
           const attachmentInfos: MessageAttachment[] = data.attachments.map(
@@ -187,35 +116,29 @@ export const useHomeSend = () => {
               }
             : undefined;
 
-          // 업로드된 파일이 있으면 뷰어 패널 열기 query param 추가
-          const queryParams = new URLSearchParams();
-          if (uploadedAssetId) {
-            queryParams.set("panel", "viewer");
-            queryParams.set("file", String(uploadedAssetId));
-          }
-
           // 첫 메시지 데이터를 state로 전달 → ChatPage에서 conversations API 호출
           const firstMessage: FirstMessageState = {
             text: data.message,
             latex: data.latex,
-            mentionedAssetIds: [
-              ...data.mentionedAssetIds,
-              ...uploadedFileAssetIds,
-            ],
+            mentionedAssetIds: data.mentionedAssetIds,
             chosenFeatures: data.mentionedToolCodes,
-            canvasImageIds: uploadedCanvasImageIds,
+            canvasImageIds: [],
             attachments: attachmentInfos,
+            pendingAttachments: data.attachments,
             viewerFile: viewerFileInfo,
+            pendingViewerFile: viewerFileRef.current ?? undefined,
           };
 
-          const queryString = queryParams.toString();
-          const path = queryString
-            ? `/app/chat/${newNoteId}?${queryString}`
-            : `/app/chat/${newNoteId}`;
-
-          navigate(path, {
+          navigate(`/app/chat/${newNoteId}`, {
             state: { firstMessage },
           });
+
+          // 저장소/노트 캐시는 네비게이션을 막지 않도록 백그라운드에서 무효화
+          void queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+          void queryClient.invalidateQueries({
+            queryKey: noteKeys.detail(String(newNoteId)),
+          });
+          void queryClient.invalidateQueries({ queryKey: assetKeys.storage });
         },
         onError: (error) => {
           console.error("노트 생성 실패:", error);
@@ -223,6 +146,8 @@ export const useHomeSend = () => {
         },
       },
     );
+
+    return true;
   };
 
   return {

--- a/src/pages/hooks/useHomeSend.ts
+++ b/src/pages/hooks/useHomeSend.ts
@@ -74,7 +74,7 @@ export const useHomeSend = () => {
 
   const clearError = () => setUploadError(null);
 
-  const handleSend = (data: ChatSendData): boolean => {
+  const handleSend = async (data: ChatSendData): Promise<boolean> => {
     const totalNotes = noteListData?.pageInfo.totalElements ?? 0;
     const resolvedPlan = profile?.subscription?.plan ?? authUser?.plan;
     const shouldCheckLimit = !isProfileLoading || !!resolvedPlan;
@@ -90,64 +90,67 @@ export const useHomeSend = () => {
       }
     }
 
-    // 노트만 생성 (title은 서버가 자동 생성)
-    createNote(
-      {},
-      {
-        onSuccess: (response) => {
-          const newNoteId = response.result.noteId;
-          setUploadError(null);
+    return new Promise<boolean>((resolve) => {
+      // 노트만 생성 (title은 서버가 자동 생성)
+      createNote(
+        {},
+        {
+          onSuccess: (response) => {
+            const newNoteId = response.result.noteId;
+            setUploadError(null);
 
-          // 첨부파일 정보 → ChatPage 전달
-          const attachmentInfos: MessageAttachment[] = data.attachments.map(
-            (a) => ({
-              name: a.name,
-              mimeType: a.mimeType,
-              size: a.size,
-              previewUrl: createPersistentPreviewUrl(a),
-            }),
-          );
+            // 첨부파일 정보 → ChatPage 전달
+            const attachmentInfos: MessageAttachment[] = data.attachments.map(
+              (a) => ({
+                name: a.name,
+                mimeType: a.mimeType,
+                size: a.size,
+                previewUrl: createPersistentPreviewUrl(a),
+              }),
+            );
 
-          const viewerFileInfo = viewerFileRef.current
-            ? {
-                name: viewerFileRef.current.name,
-                mimeType: viewerFileRef.current.type,
-                size: viewerFileRef.current.size,
-              }
-            : undefined;
+            const viewerFileInfo = viewerFileRef.current
+              ? {
+                  name: viewerFileRef.current.name,
+                  mimeType: viewerFileRef.current.type,
+                  size: viewerFileRef.current.size,
+                }
+              : undefined;
 
-          // 첫 메시지 데이터를 state로 전달 → ChatPage에서 conversations API 호출
-          const firstMessage: FirstMessageState = {
-            text: data.message,
-            latex: data.latex,
-            mentionedAssetIds: data.mentionedAssetIds,
-            chosenFeatures: data.mentionedToolCodes,
-            canvasImageIds: [],
-            attachments: attachmentInfos,
-            pendingAttachments: data.attachments,
-            viewerFile: viewerFileInfo,
-            pendingViewerFile: viewerFileRef.current ?? undefined,
-          };
+            // 첫 메시지 데이터를 state로 전달 → ChatPage에서 conversations API 호출
+            const firstMessage: FirstMessageState = {
+              text: data.message,
+              latex: data.latex,
+              mentionedAssetIds: data.mentionedAssetIds,
+              chosenFeatures: data.mentionedToolCodes,
+              canvasImageIds: [],
+              attachments: attachmentInfos,
+              pendingAttachments: data.attachments,
+              viewerFile: viewerFileInfo,
+              pendingViewerFile: viewerFileRef.current ?? undefined,
+            };
 
-          navigate(`/app/chat/${newNoteId}`, {
-            state: { firstMessage },
-          });
+            navigate(`/app/chat/${newNoteId}`, {
+              state: { firstMessage },
+            });
 
-          // 저장소/노트 캐시는 네비게이션을 막지 않도록 백그라운드에서 무효화
-          void queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
-          void queryClient.invalidateQueries({
-            queryKey: noteKeys.detail(String(newNoteId)),
-          });
-          void queryClient.invalidateQueries({ queryKey: assetKeys.storage });
+            // 저장소/노트 캐시는 네비게이션을 막지 않도록 백그라운드에서 무효화
+            void queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+            void queryClient.invalidateQueries({
+              queryKey: noteKeys.detail(String(newNoteId)),
+            });
+            void queryClient.invalidateQueries({ queryKey: assetKeys.storage });
+
+            resolve(true);
+          },
+          onError: (error) => {
+            console.error("노트 생성 실패:", error);
+            setUploadError("노트 생성에 실패했습니다. 다시 시도해주세요.");
+            resolve(false);
+          },
         },
-        onError: (error) => {
-          console.error("노트 생성 실패:", error);
-          setUploadError("노트 생성에 실패했습니다. 다시 시도해주세요.");
-        },
-      },
-    );
-
-    return true;
+      );
+    });
   };
 
   return {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #198 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- useHomeSend: 기존의 홈 업로드 await 제거 -> 항상 /app/chat/:noteId 즉시 navigate
- FirstMessageState에 pendingAttachments, pendingViewerFile 추가
- useChatMessages: 첫 메시지 전 업로드 처리 + 업로드 결과 assetId를 mentionedAssetIds / canvasImageIds 병합
- 뷰어 업로드 성공 시 URL 쿼리 (panel=viewer&file=...)도 채팅 페이지에서 갱신
- 홈 전송 핸들러가 노트 생성 시작 가능 여부를 boolean으로 반환하도록 변경
  - 최대 노트 제한에 걸리면 false 반환(노트 생성 중단)
- ChatInput.tsx: 홈 전송 분기에서 onSend 결과를 await 후, false면 즉시 종료
  - false일 때, 크레딧 차감 요청을 보내지 않도록 처리

### 홈 전송 (isHomeSend) 흐름
```
[사용자 전송 클릭]
      |
      v
[ChatInput.handleSend 시작]
      |
      v
[onSend(sendPayload) await]  ----> (useHomeSend.handleSend)
                                  |
                                  +--> 최대 노트 초과? -> resolve(false)
                                  |
                                  +--> createNote 호출
                                         |
                                         +--> 성공 onSuccess -> resolve(true)
                                         +--> 실패 onError  -> resolve(false)
      |
      v
[sendResult === true ?]
   | yes                          | no
   v                              v
[입력 초기화]                 [즉시 종료, 차감 안함]
   |
   v
[deductCredit(...) fire-and-forget]
   |
   +--> .then: success false면 warn
   +--> .catch: 네트워크/throw 에러 처리
``` 
- 핵심: 노트 생성 성공(true)일 때만 크레딧 차감으로 넘어감

### 비홈 전송(채팅방 내부) 흐름
```
[사용자 전송 클릭]
      |
      v
[deductCredit await]
   |
   +--> 실패/에러 -> 사용자 안내 후 return
   |
   +--> 성공 -> onSend(sendPayload) await
                     |
                     +--> 실패면 catch에서 사용자 안내
                     +--> 성공이면 입력 초기화
      |
      v
[finally: setIsProcessing(false)]
``` 
- 핵심: 차감/전송 둘 다 await + try/catch로 실패를 제어

## 📸 스크린샷

<img width="1871" height="799" alt="image" src="https://github.com/user-attachments/assets/4b4b877d-c6ad-445d-a738-a37e74d0d22e" />

- 홈 화면에서 채팅 전송 시, 바로 노트 화면으로 이동
- 파일 첨부(뷰어로 업로드, 클립 버튼), 크레딧 차감은 백그라운드로 처리
- 낙관적 업데이트 적용

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 메시지 작성 시 파일 업로드 및 첨부 지원 추가(뷰어 파일 포함), 전송 흐름에서 첨부 관리 가능.

* **Improvements**
  * 첫 메시지 전송 후 자동으로 뷰어 패널로 이동해 파일을 즉시 확인.
  * 전송·신용 차감 플로우 개선으로 더 일관된 처리 및 빠른 응답성 제공.
  * 낙관적 UI 업데이트로 신용 잔액 반영이 즉시 표시됨.

* **Bug Fixes**
  * 업로드/전송 실패 시 UI 상태 및 오류 알림 처리 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->