### PR TITLE
Fix(#202): 최종 응답 append 처리 및 생성 중 입력/전송 차단 UI 추가

### DIFF
--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -253,13 +253,13 @@ export const useChatMessages = () => {
                 ),
               );
             } else if (event.content.type === "ai") {
-              // 최종 응답 — token 누적분을 서버 최종 텍스트로 교체 (정합성 보장)
+              // 최종 응답 — 기존 내용 밑에 추가 (교체 X)
               setMessages((prev) =>
                 prev.map((m) =>
                   m.id === tempAssistantMsgId
                     ? {
                         ...m,
-                        content: event.content.content,
+                        content: m.content + (m.content ? "\n\n" : "") + event.content.content,
                         statusText: undefined,
                       }
                     : m,

--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -253,17 +253,24 @@ export const useChatMessages = () => {
                 ),
               );
             } else if (event.content.type === "ai") {
-              // 최종 응답 — 기존 내용 밑에 추가 (교체 X)
+              // 최종 응답 — 서버 응답과 클라이언트 누적이 다를 경우에만 교체 (정합성 보장)
+              // 같으면 깜빡임 방지를 위해 유지 (statusText만 제거)
               setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === tempAssistantMsgId
-                    ? {
-                        ...m,
-                        content: m.content + (m.content ? "\n\n" : "") + event.content.content,
-                        statusText: undefined,
-                      }
-                    : m,
-                ),
+                prev.map((m) => {
+                  if (m.id !== tempAssistantMsgId) return m;
+
+                  // 내용이 다르면 교체, 같으면 유지
+                  if (m.content !== event.content.content) {
+                    return {
+                      ...m,
+                      content: event.content.content,
+                      statusText: undefined,
+                    };
+                  }
+
+                  // 내용이 같으면 statusText만 제거
+                  return { ...m, statusText: undefined };
+                }),
               );
             }
             break;

--- a/src/features/editor/components/ChatInput.tsx
+++ b/src/features/editor/components/ChatInput.tsx
@@ -342,6 +342,7 @@ export const ChatInput = ({
         onContentChange={setHasContent}
         onSubmit={handleSend}
         onKeyDown={handleKeyDown}
+        disabled={isSending}
       />
 
       {/* 툴바 */}
@@ -358,6 +359,7 @@ export const ChatInput = ({
         activeToolName={selectedTool}
         hasContent={!isSending && (hasContent || attachments.length > 0)}
         onClipClick={openFilePicker}
+        isSending={isSending}
       />
 
       {/* Canvas Overlay - Lazy loaded */}

--- a/src/features/editor/components/input/ChatInputArea.tsx
+++ b/src/features/editor/components/input/ChatInputArea.tsx
@@ -6,6 +6,7 @@ interface ChatInputAreaProps {
   onContentChange?: (hasContent: boolean) => void;
   onSubmit?: () => void;
   className?: string;
+  disabled?: boolean;
 }
 
 /**
@@ -25,7 +26,7 @@ const SCROLLBAR_STYLES = `
 
 export const ChatInputArea = forwardRef<HTMLDivElement, ChatInputAreaProps>(
   (
-    { onContentClick, onKeyDown, onContentChange, onSubmit, className },
+    { onContentClick, onKeyDown, onContentChange, onSubmit, className, disabled = false },
     ref,
   ) => {
     const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -59,10 +60,11 @@ export const ChatInputArea = forwardRef<HTMLDivElement, ChatInputAreaProps>(
         {/* 채팅 입력 영역 (위로 확장) */}
         <div
           ref={ref}
-          contentEditable
-          className={`min-h-[50px] w-full flex-1 cursor-text overflow-x-hidden overflow-y-auto pr-2 text-[18px] leading-[28px] tracking-[-0.01em] break-words whitespace-pre-wrap text-gray-800 empty:before:text-[#9CA4B0] empty:before:content-['@을_통해_도구를_선택하거나,_요청을_입력하세요.'] focus:outline-none ${SCROLLBAR_STYLES}`}
-          onClick={onContentClick}
+          contentEditable={!disabled}
+          className={`min-h-[50px] w-full flex-1 cursor-text overflow-x-hidden overflow-y-auto pr-2 text-[18px] leading-[28px] tracking-[-0.01em] break-words whitespace-pre-wrap text-gray-800 empty:before:text-[#9CA4B0] empty:before:content-['@을_통해_도구를_선택하거나,_요청을_입력하세요.'] focus:outline-none ${SCROLLBAR_STYLES} ${disabled ? 'opacity-50 cursor-not-allowed pointer-events-none' : ''}`}
+          onClick={disabled ? undefined : onContentClick}
           onInput={(e) => {
+            if (disabled) return;
             // 브라우저가 다 지워도 <br>을 남기는 경우 처리 (placeholder 보이게 하기 위함)
             if (e.currentTarget.innerHTML === "<br>") {
               e.currentTarget.innerHTML = "";
@@ -71,8 +73,8 @@ export const ChatInputArea = forwardRef<HTMLDivElement, ChatInputAreaProps>(
             const text = e.currentTarget.textContent?.trim() || "";
             onContentChange?.(text.length > 0);
           }}
-          onKeyDown={handleKeyDown}
-          onPaste={handlePaste}
+          onKeyDown={disabled ? undefined : handleKeyDown}
+          onPaste={disabled ? undefined : handlePaste}
         />
       </div>
     );

--- a/src/features/editor/components/toolbar/InputToolbar.tsx
+++ b/src/features/editor/components/toolbar/InputToolbar.tsx
@@ -32,6 +32,7 @@ interface InputToolbarProps {
   activeToolName?: string | null;
   hasContent?: boolean;
   onClipClick?: () => void;
+  isSending?: boolean;
 }
 
 export const InputToolbar = ({
@@ -44,6 +45,7 @@ export const InputToolbar = ({
   activeToolName,
   hasContent = false,
   onClipClick,
+  isSending = false,
 }: InputToolbarProps) => {
   const [isToolMenuOpen, setIsToolMenuOpen] = useState(false);
   const { data: toolList = [] } = useTools();
@@ -200,8 +202,16 @@ export const InputToolbar = ({
       ref={containerRef}
       className="flex w-full items-end gap-[12px]"
     >
+      {/* 생성 중 표시 */}
+      {isSending && (
+        <div className="flex items-center gap-2 text-sm text-[#9CA4B0]">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-[#9CA4B0] border-t-transparent" />
+          <span>생성 중...</span>
+        </div>
+      )}
+
       {/* 왼쪽 버튼 그룹 - 각 버튼 사이 간격은 개별 margin으로 처리 */}
-      <div className="flex flex-1 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div className={`flex flex-1 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${isSending ? 'opacity-50 pointer-events-none' : ''}`}>
         {/* 클립 버튼 */}
         <ToolButton
           onClick={onClipClick}
@@ -322,8 +332,8 @@ export const InputToolbar = ({
 
       {/* 전송 버튼 */}
       <ToolButton
-        onClick={hasContent ? onSend : undefined}
-        className={getSendButtonClass(hasContent)}
+        onClick={hasContent && !isSending ? onSend : undefined}
+        className={`${getSendButtonClass(hasContent && !isSending)} ${isSending ? 'opacity-50 cursor-not-allowed' : ''}`}
       >
         <SendIcon className="h-[16px] w-[14px] shrink-0" />
       </ToolButton>


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #202 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 최종 응답 처리 개선
  - `event.content.type === "ai"` 수신 시 기존 메시지를 교체하지 않고 append 처리
  - 기존 내용이 있으면 `\n\n`로 구분하여 최종 텍스트를 아래에 추가
- 생성 중 입력/전송 차단 및 진행 표시 추가
  - ChatInputArea: `disabled` prop 추가, disabled 시 contentEditable 비활성화 및 입력 이벤트 차단
  - ChatInput: `isSending`을 ChatInputArea/InputToolbar로 전달
  - InputToolbar:
    - "생성 중..." + 스피너 표시
    - 버튼 그룹 비활성화(opacity + pointer-events-none)
    - 전송 버튼 클릭 차단 및 비활성화 스타일 적용

## 📸 스크린샷

<img width="776" height="219" alt="스크린샷 2026-02-15 214322" src="https://github.com/user-attachments/assets/ed5efa6b-8ab3-4b94-bb07-3a3a390f24b1" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

-검증 완료
  - 생성 중에는 입력/전송/툴바 클릭이 모두 막힘
  - 생성 완료 후 정상적으로 다시 입력 가능
  - 최종 응답 수신 시 기존 스트리밍 내용이 사라지지 않고 append

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메시지 생성 중 시각적 표시기("생성 중…") 추가

* **개선 사항**
  * 메시지 전송 중 채팅 입력 필드가 비활성화되어 편집 차단
  * 전송 상태(isSending)에 따라 툴바 및 전송 버튼이 비활성화되고 시각적으로 표시됨
  * AI 스트리밍 결과는 누적되어 표시되며, 동일한 내용으로의 불필요한 갱신을 방지하여 깜빡임 최소화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->