### PR TITLE
Fix(#204): 채팅 전송 후 답변 완성될 때까지 로딩 스피너 추가, # 파일 첨부 스타일 추가

### DIFF
--- a/src/features/chat/components/rightpanel/ChatMessages.tsx
+++ b/src/features/chat/components/rightpanel/ChatMessages.tsx
@@ -12,40 +12,6 @@ interface ChatMessagesProps {
   messages: ChatMessage[];
 }
 
-const FILE_MENTION_REGEX =
-  /#([\w\d가-힣ㄱ-ㅎㅏ-ㅣ\s()\-_.]+?\.(?:pdf|png|jpe?g|webp|gif|bmp|svg|txt|docx?|pptx?|xlsx?|csv|hwp|hwpx))/gi;
-
-const UserMessageContent = ({ content }: { content: string }) => {
-  const lines = content.split("\n");
-
-  return (
-    <>
-      {lines.map((line, lineIndex) => {
-        const parts = line.split(FILE_MENTION_REGEX);
-
-        return (
-          <div key={`line-${lineIndex}`}>
-            {parts.map((part, partIndex) => {
-              if (partIndex % 2 === 1) {
-                return (
-                  <span
-                    key={`chip-${lineIndex}-${partIndex}`}
-                    className="inline-flex rounded-[6px] bg-[#DDE7FA] px-1.5 py-0.5 align-middle text-[#3A5BA9]"
-                  >
-                    #{part}
-                  </span>
-                );
-              }
-
-              return <span key={`text-${lineIndex}-${partIndex}`}>{part}</span>;
-            })}
-          </div>
-        );
-      })}
-    </>
-  );
-};
-
 // 사용자 메시지 컴포넌트
 const UserMessage = ({ message }: { message: ChatMessage }) => (
   <div className="flex flex-col items-end">
@@ -57,7 +23,10 @@ const UserMessage = ({ message }: { message: ChatMessage }) => (
     <div className="flex items-start justify-end gap-[12px]">
       <div className="max-w-[400px] overflow-hidden rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-white p-[10px]">
         <div className="text-[14px] leading-[20px] font-medium break-words whitespace-pre-wrap text-black">
-          <UserMessageContent content={message.content} />
+          <MessageContent
+            content={message.content}
+            enableFileMentionChip={true}
+          />
         </div>
       </div>
       <div className="shrink-0">

--- a/src/features/chat/components/rightpanel/ChatMessages.tsx
+++ b/src/features/chat/components/rightpanel/ChatMessages.tsx
@@ -12,6 +12,40 @@ interface ChatMessagesProps {
   messages: ChatMessage[];
 }
 
+const FILE_MENTION_REGEX =
+  /#([\w\d가-힣ㄱ-ㅎㅏ-ㅣ\s()\-_.]+?\.(?:pdf|png|jpe?g|webp|gif|bmp|svg|txt|docx?|pptx?|xlsx?|csv|hwp|hwpx))/gi;
+
+const UserMessageContent = ({ content }: { content: string }) => {
+  const lines = content.split("\n");
+
+  return (
+    <>
+      {lines.map((line, lineIndex) => {
+        const parts = line.split(FILE_MENTION_REGEX);
+
+        return (
+          <div key={`line-${lineIndex}`}>
+            {parts.map((part, partIndex) => {
+              if (partIndex % 2 === 1) {
+                return (
+                  <span
+                    key={`chip-${lineIndex}-${partIndex}`}
+                    className="inline-flex rounded-[6px] bg-[#DDE7FA] px-1.5 py-0.5 align-middle text-[#3A5BA9]"
+                  >
+                    #{part}
+                  </span>
+                );
+              }
+
+              return <span key={`text-${lineIndex}-${partIndex}`}>{part}</span>;
+            })}
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
 // 사용자 메시지 컴포넌트
 const UserMessage = ({ message }: { message: ChatMessage }) => (
   <div className="flex flex-col items-end">
@@ -23,7 +57,7 @@ const UserMessage = ({ message }: { message: ChatMessage }) => (
     <div className="flex items-start justify-end gap-[12px]">
       <div className="max-w-[400px] overflow-hidden rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-white p-[10px]">
         <div className="text-[14px] leading-[20px] font-medium break-words whitespace-pre-wrap text-black">
-          <MessageContent content={message.content} />
+          <UserMessageContent content={message.content} />
         </div>
       </div>
       <div className="shrink-0">

--- a/src/features/chat/components/rightpanel/MessageContent.tsx
+++ b/src/features/chat/components/rightpanel/MessageContent.tsx
@@ -94,19 +94,17 @@ export const MessageContent = ({
           ),
           br: () => <br />,
           ul: ({ children }) => (
-            <ul className="my-2 list-disc pl-5">{renderContent(children)}</ul>
+            <ul className="my-2 list-disc pl-5">{children}</ul>
           ),
           ol: ({ children }) => (
-            <ol className="my-2 list-decimal pl-5">
-              {renderContent(children)}
-            </ol>
+            <ol className="my-2 list-decimal pl-5">{children}</ol>
           ),
           li: ({ children }) => (
             <li className="my-1">{renderContent(children)}</li>
           ),
           blockquote: ({ children }) => (
             <blockquote className="my-2 border-l-2 border-gray-300 pl-3 text-gray-600">
-              {renderContent(children)}
+              {children}
             </blockquote>
           ),
           code: ({ className: codeClassName, children }) => (

--- a/src/features/chat/components/rightpanel/MessageContent.tsx
+++ b/src/features/chat/components/rightpanel/MessageContent.tsx
@@ -1,3 +1,4 @@
+import { Children, cloneElement, isValidElement, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -7,7 +8,52 @@ import "katex/dist/katex.min.css";
 interface MessageContentProps {
   content: string;
   className?: string;
+  enableFileMentionChip?: boolean;
 }
+
+const FILE_MENTION_REGEX =
+  /#([\w\d가-힣ㄱ-ㅎㅏ-ㅣ\s()\-_.]+?\.(?:pdf|png|jpe?g|webp|gif|bmp|svg|txt|docx?|pptx?|xlsx?|csv|hwp|hwpx))/gi;
+
+const renderMentionChipsInText = (text: string): ReactNode => {
+  const parts = text.split(FILE_MENTION_REGEX);
+
+  if (parts.length === 1) {
+    return text;
+  }
+
+  return parts.map((part, index) => {
+    if (index % 2 === 1) {
+      return (
+        <span
+          key={`mention-chip-${index}-${part}`}
+          className="inline-flex rounded-[6px] bg-[#DDE7FA] px-1.5 py-0.5 align-middle text-[#3A5BA9]"
+        >
+          #{part}
+        </span>
+      );
+    }
+
+    return part;
+  });
+};
+
+const applyMentionChipToChildren = (children: ReactNode): ReactNode =>
+  Children.map(children, (child) => {
+    if (typeof child === "string") {
+      return renderMentionChipsInText(child);
+    }
+
+    if (
+      isValidElement<{ children?: ReactNode }>(child) &&
+      child.props.children !== undefined
+    ) {
+      return cloneElement(child, {
+        children: applyMentionChipToChildren(child.props.children),
+      });
+    }
+
+    return child;
+  });
 
 /**
  * MessageContent - 메시지 내용 렌더링 컴포넌트
@@ -17,7 +63,11 @@ interface MessageContentProps {
 export const MessageContent = ({
   content,
   className = "",
+  enableFileMentionChip = false,
 }: MessageContentProps) => {
+  const renderContent = (children: ReactNode) =>
+    enableFileMentionChip ? applyMentionChipToChildren(children) : children;
+
   return (
     <div className={className}>
       <ReactMarkdown
@@ -25,26 +75,38 @@ export const MessageContent = ({
         rehypePlugins={[rehypeKatex]}
         components={{
           h1: ({ children }) => (
-            <h1 className="my-2 text-[18px] font-semibold">{children}</h1>
+            <h1 className="my-2 text-[18px] font-semibold">
+              {renderContent(children)}
+            </h1>
           ),
           h2: ({ children }) => (
-            <h2 className="my-2 text-[16px] font-semibold">{children}</h2>
+            <h2 className="my-2 text-[16px] font-semibold">
+              {renderContent(children)}
+            </h2>
           ),
           h3: ({ children }) => (
-            <h3 className="my-2 text-[15px] font-semibold">{children}</h3>
+            <h3 className="my-2 text-[15px] font-semibold">
+              {renderContent(children)}
+            </h3>
           ),
-          p: ({ children }) => <p className="my-1">{children}</p>,
+          p: ({ children }) => (
+            <p className="my-1">{renderContent(children)}</p>
+          ),
           br: () => <br />,
           ul: ({ children }) => (
-            <ul className="my-2 list-disc pl-5">{children}</ul>
+            <ul className="my-2 list-disc pl-5">{renderContent(children)}</ul>
           ),
           ol: ({ children }) => (
-            <ol className="my-2 list-decimal pl-5">{children}</ol>
+            <ol className="my-2 list-decimal pl-5">
+              {renderContent(children)}
+            </ol>
           ),
-          li: ({ children }) => <li className="my-1">{children}</li>,
+          li: ({ children }) => (
+            <li className="my-1">{renderContent(children)}</li>
+          ),
           blockquote: ({ children }) => (
             <blockquote className="my-2 border-l-2 border-gray-300 pl-3 text-gray-600">
-              {children}
+              {renderContent(children)}
             </blockquote>
           ),
           code: ({ className: codeClassName, children }) => (
@@ -66,7 +128,7 @@ export const MessageContent = ({
               rel="noreferrer"
               className="text-blue-600 underline"
             >
-              {children}
+              {renderContent(children)}
             </a>
           ),
           table: ({ children }) => (
@@ -78,11 +140,13 @@ export const MessageContent = ({
           ),
           th: ({ children }) => (
             <th className="border border-gray-200 bg-gray-50 px-2 py-1 text-left">
-              {children}
+              {renderContent(children)}
             </th>
           ),
           td: ({ children }) => (
-            <td className="border border-gray-200 px-2 py-1">{children}</td>
+            <td className="border border-gray-200 px-2 py-1">
+              {renderContent(children)}
+            </td>
           ),
         }}
       >

--- a/src/features/chat/pages/ChatPage.tsx
+++ b/src/features/chat/pages/ChatPage.tsx
@@ -61,7 +61,7 @@ const ChatPageContent = () => {
   return (
     <div
       id="chat-container"
-      className="flex h-full w-full flex-col"
+      className="flex h-full min-h-0 w-full flex-col overflow-hidden"
     >
       <ChatHeader
         title={noteTitle}

--- a/src/features/editor/components/ChatInput.tsx
+++ b/src/features/editor/components/ChatInput.tsx
@@ -143,10 +143,12 @@ export const ChatInput = ({
 
   // 크레딧 사용 뮤테이션
   const { mutateAsync: deductCredit } = useUseCredit();
+  const isHomeSend = noteId == null;
+  const isToolbarSending = !isHomeSend && isSending;
 
   // 전송 핸들러
   const handleSend = async () => {
-    if (isSending || isProcessing) return;
+    if (isToolbarSending || isProcessing) return;
     if (!hasContent && attachments.length === 0) return;
 
     // DOM에서 콘텐츠 추출 (텍스트 + LaTeX + 멘션)
@@ -183,8 +185,6 @@ export const ChatInput = ({
       clearAttachments();
       handleToolSelect(""); // 선택된 도구 초기화
     };
-
-    const isHomeSend = noteId == null;
 
     // 홈에서는 이동을 막지 않도록 먼저 전송(onSend) 후 크레딧 차감은 백그라운드 처리
     if (isHomeSend) {
@@ -243,8 +243,8 @@ export const ChatInput = ({
 
     try {
       // 부모 콜백 호출
-      await onSend?.(sendPayload);
       resetInputState();
+      await onSend?.(sendPayload);
     } catch (error) {
       console.error("Send failed:", error);
       alert("메시지 전송 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
@@ -342,7 +342,6 @@ export const ChatInput = ({
         onContentChange={setHasContent}
         onSubmit={handleSend}
         onKeyDown={handleKeyDown}
-        disabled={isSending}
       />
 
       {/* 툴바 */}
@@ -357,9 +356,9 @@ export const ChatInput = ({
         onSend={handleSend}
         onToolSelect={(tool) => handleToolSelect(tool, false)}
         activeToolName={selectedTool}
-        hasContent={!isSending && (hasContent || attachments.length > 0)}
+        hasContent={hasContent || attachments.length > 0}
         onClipClick={openFilePicker}
-        isSending={isSending}
+        isSending={isToolbarSending}
       />
 
       {/* Canvas Overlay - Lazy loaded */}

--- a/src/features/editor/components/ChatInput.tsx
+++ b/src/features/editor/components/ChatInput.tsx
@@ -84,6 +84,7 @@ export const ChatInput = ({
     attachments,
     addFiles,
     addCanvasImage,
+    restoreAttachments,
     removeAttachment,
     clearAttachments,
     openFilePicker,
@@ -176,6 +177,12 @@ export const ChatInput = ({
       attachments: [...attachments],
     };
 
+    const restoreSnapshot = {
+      text: sendPayload.message,
+      attachments: [...attachments],
+      selectedToolName: selectedTool,
+    };
+
     const resetInputState = () => {
       if (inputRef.current) {
         inputRef.current.innerHTML = "";
@@ -184,6 +191,16 @@ export const ChatInput = ({
       clearMentionedAssets();
       clearAttachments();
       handleToolSelect(""); // 선택된 도구 초기화
+    };
+
+    const restoreInputState = () => {
+      if (inputRef.current) {
+        inputRef.current.innerText = restoreSnapshot.text;
+      }
+      setHasContent(restoreSnapshot.text.trim().length > 0);
+      restoreAttachments(restoreSnapshot.attachments);
+      clearMentionedAssets();
+      handleToolSelect(restoreSnapshot.selectedToolName || "");
     };
 
     // 홈에서는 이동을 막지 않도록 먼저 전송(onSend) 후 크레딧 차감은 백그라운드 처리
@@ -246,6 +263,7 @@ export const ChatInput = ({
       resetInputState();
       await onSend?.(sendPayload);
     } catch (error) {
+      restoreInputState();
       console.error("Send failed:", error);
       alert("메시지 전송 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
     } finally {

--- a/src/features/editor/components/input/ChatInputArea.tsx
+++ b/src/features/editor/components/input/ChatInputArea.tsx
@@ -26,7 +26,14 @@ const SCROLLBAR_STYLES = `
 
 export const ChatInputArea = forwardRef<HTMLDivElement, ChatInputAreaProps>(
   (
-    { onContentClick, onKeyDown, onContentChange, onSubmit, className, disabled = false },
+    {
+      onContentClick,
+      onKeyDown,
+      onContentChange,
+      onSubmit,
+      className,
+      disabled = false,
+    },
     ref,
   ) => {
     const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -61,7 +68,7 @@ export const ChatInputArea = forwardRef<HTMLDivElement, ChatInputAreaProps>(
         <div
           ref={ref}
           contentEditable={!disabled}
-          className={`min-h-[50px] w-full flex-1 cursor-text overflow-x-hidden overflow-y-auto pr-2 text-[18px] leading-[28px] tracking-[-0.01em] break-words whitespace-pre-wrap text-gray-800 empty:before:text-[#9CA4B0] empty:before:content-['@을_통해_도구를_선택하거나,_요청을_입력하세요.'] focus:outline-none ${SCROLLBAR_STYLES} ${disabled ? 'opacity-50 cursor-not-allowed pointer-events-none' : ''}`}
+          className={`min-h-[50px] w-full flex-1 cursor-text overflow-x-hidden overflow-y-auto pr-2 text-[18px] leading-[28px] tracking-[-0.01em] break-words whitespace-pre-wrap text-gray-800 empty:before:text-[#9CA4B0] empty:before:content-['@을_통해_도구를_선택하거나,_요청을_입력하세요.'] focus:outline-none ${SCROLLBAR_STYLES} ${disabled ? "pointer-events-none cursor-not-allowed opacity-50" : ""}`}
           onClick={disabled ? undefined : onContentClick}
           onInput={(e) => {
             if (disabled) return;

--- a/src/features/editor/components/toolbar/InputToolbar.tsx
+++ b/src/features/editor/components/toolbar/InputToolbar.tsx
@@ -8,6 +8,7 @@ import {
   MathIcon,
   CanvasIcon,
 } from "../../../../shared/components/icons/ChatInputIcons";
+import { LoadingSpinner } from "@/shared/components/loading-spinner";
 import { ToolButton } from "./ToolButton";
 import { ToolDropdownMenu } from "../input/ToolDropdownMenu";
 import { useTools } from "../../hooks/useEditorQueries";
@@ -202,16 +203,8 @@ export const InputToolbar = ({
       ref={containerRef}
       className="flex w-full items-end gap-[12px]"
     >
-      {/* 생성 중 표시 */}
-      {isSending && (
-        <div className="flex items-center gap-2 text-sm text-[#9CA4B0]">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-[#9CA4B0] border-t-transparent" />
-          <span>생성 중...</span>
-        </div>
-      )}
-
       {/* 왼쪽 버튼 그룹 - 각 버튼 사이 간격은 개별 margin으로 처리 */}
-      <div className={`flex flex-1 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${isSending ? 'opacity-50 pointer-events-none' : ''}`}>
+      <div className="flex flex-1 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {/* 클립 버튼 */}
         <ToolButton
           onClick={onClipClick}
@@ -333,9 +326,13 @@ export const InputToolbar = ({
       {/* 전송 버튼 */}
       <ToolButton
         onClick={hasContent && !isSending ? onSend : undefined}
-        className={`${getSendButtonClass(hasContent && !isSending)} ${isSending ? 'opacity-50 cursor-not-allowed' : ''}`}
+        className={`${getSendButtonClass(hasContent && !isSending)} ${isSending ? "cursor-not-allowed opacity-50" : ""}`}
       >
-        <SendIcon className="h-[16px] w-[14px] shrink-0" />
+        {isSending ? (
+          <LoadingSpinner size={16} />
+        ) : (
+          <SendIcon className="h-[16px] w-[14px] shrink-0" />
+        )}
       </ToolButton>
     </div>
   );

--- a/src/features/editor/components/toolbar/InputToolbar.tsx
+++ b/src/features/editor/components/toolbar/InputToolbar.tsx
@@ -326,10 +326,10 @@ export const InputToolbar = ({
       {/* 전송 버튼 */}
       <ToolButton
         onClick={hasContent && !isSending ? onSend : undefined}
-        className={`${getSendButtonClass(hasContent && !isSending)} ${isSending ? "cursor-not-allowed opacity-50" : ""}`}
+        className={`${getSendButtonClass(hasContent && !isSending)} ${isSending ? "cursor-not-allowed" : ""}`}
       >
         {isSending ? (
-          <LoadingSpinner size={16} />
+          <LoadingSpinner size={20} />
         ) : (
           <SendIcon className="h-[16px] w-[14px] shrink-0" />
         )}

--- a/src/features/editor/hooks/useAttachments.ts
+++ b/src/features/editor/hooks/useAttachments.ts
@@ -37,6 +37,7 @@ interface UseAttachmentsReturn {
   attachments: Attachment[];
   addFiles: (files: FileList | File[]) => void;
   addCanvasImage: (blob: Blob) => void;
+  restoreAttachments: (attachments: Attachment[]) => void;
   removeAttachment: (id: string) => void;
   clearAttachments: () => void;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
@@ -155,6 +156,36 @@ export const useAttachments = (): UseAttachmentsReturn => {
     });
   }, []);
 
+  /** 실패 복구용 첨부 재설정 */
+  const restoreAttachments = useCallback((nextAttachments: Attachment[]) => {
+    setAttachments((prev) => {
+      prev.forEach((item) => {
+        if (item.previewUrl) {
+          URL.revokeObjectURL(item.previewUrl);
+        }
+      });
+
+      return nextAttachments.map((attachment) => {
+        let previewUrl: string | undefined;
+
+        if (attachment.type === "canvas" && attachment.blob) {
+          previewUrl = URL.createObjectURL(attachment.blob);
+        } else if (
+          attachment.mimeType.startsWith("image/") &&
+          attachment.file
+        ) {
+          previewUrl = URL.createObjectURL(attachment.file);
+        }
+
+        return {
+          ...attachment,
+          id: generateId(),
+          previewUrl,
+        };
+      });
+    });
+  }, []);
+
   /** 드래그앤드롭 핸들러 */
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -215,6 +246,7 @@ export const useAttachments = (): UseAttachmentsReturn => {
     attachments,
     addFiles,
     addCanvasImage,
+    restoreAttachments,
     removeAttachment,
     clearAttachments,
     fileInputRef,

--- a/src/shared/components/loading-spinner/LoadingSpinner.tsx
+++ b/src/shared/components/loading-spinner/LoadingSpinner.tsx
@@ -1,3 +1,5 @@
+import { useId } from "react";
+
 interface LoadingSpinnerProps {
   /** 스피너 크기 (기본: 160px) */
   size?: number;
@@ -14,6 +16,7 @@ export const LoadingSpinner = ({
   size = 160,
   className = "",
 }: LoadingSpinnerProps) => {
+  const gradientId = `spinnerGradient-${useId().replace(/:/g, "")}`;
   const strokeWidth = size * 0.1; // 스트로크 두께 (크기의 10%)
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
@@ -33,7 +36,7 @@ export const LoadingSpinner = ({
         <defs>
           {/* 그라데이션 정의 */}
           <linearGradient
-            id="spinnerGradient"
+            id={gradientId}
             x1="0%"
             y1="0%"
             x2="100%"
@@ -74,7 +77,7 @@ export const LoadingSpinner = ({
           cy={size / 2}
           r={radius}
           fill="none"
-          stroke="url(#spinnerGradient)"
+          stroke={`url(#${gradientId})`}
           strokeWidth={strokeWidth}
           strokeLinecap="round"
           strokeDasharray={circumference}

--- a/src/shared/layout/AppLayout.tsx
+++ b/src/shared/layout/AppLayout.tsx
@@ -33,6 +33,7 @@ export const AppLayout = () => {
   };
 
   const isHomePage = location.pathname === "/app/home";
+  const isChatPage = location.pathname.startsWith("/app/chat");
 
   const handleHomeClick = () => {
     if (isHomePage) {
@@ -60,7 +61,11 @@ export const AppLayout = () => {
       />
 
       {/* 오른쪽 본문 영역 (Outlet) - 사이드바 너비에 따라 자동으로 밀림 */}
-      <main className="relative flex flex-1 flex-col overflow-y-auto transition-all duration-300">
+      <main
+        className={`relative flex min-h-0 flex-1 flex-col transition-all duration-300 ${
+          isChatPage ? "overflow-hidden" : "overflow-y-auto"
+        }`}
+      >
         <Outlet />
       </main>
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #204 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [x] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 채팅 전송 중에는 전송 아이콘 대신 LoadingSpinner 표시
- #파일명.ext 로 멘션된 텍스트는 전송 후 사용자 메시지에서도 파란 칩 스타일 유지
  - 사용자 메시지 전용 렌더러 (UserMessageContent) 추가 

## 📸 스크린샷

<img width="913" height="307" alt="image" src="https://github.com/user-attachments/assets/f62e39a0-2051-4efc-bad5-7d5909ed02ed" />

- AI의 응답이 완벽하게 올 때까지, 전송 버튼이 로딩 스피너로 전환

<img width="786" height="398" alt="image" src="https://github.com/user-attachments/assets/e3889d63-9312-48a1-a696-f5e576d361d5" />

- #으로 파일 첨부 후 채팅 전송 시, 사용자 메시지에도 동일하게 파란색 칩 유지

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 메시지 내 파일 언급을 인식해 인라인 칩으로 표시
  * 전송 실패 시 입력 텍스트·첨부파일·툴 상태를 복원하는 기능 추가
  * 첨부파일 복원 기능(전송 실패 시 첨부 재설정) 제공

* **버그 수정**
  * 채팅 페이지 레이아웃과 스크롤 클리핑 개선으로 레이아웃 안정성 향상

* **스타일**
  * 전송 버튼에 로딩 스피너 표시로 전송 중 UI 개선 및 툴바 상호작용 유지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->