### PR TITLE
Fix(#206): 채팅 전송 시 하단 여백 문제 해결

### DIFF
--- a/src/features/chat/components/rightpanel/ChatMessages.tsx
+++ b/src/features/chat/components/rightpanel/ChatMessages.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useLayoutEffect } from "react";
 import {
   ProfileIcon,
   SubscriptionIcon,
@@ -71,22 +71,98 @@ const AssistantMessage = ({
 export const ChatMessages = ({ messages }: ChatMessagesProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const lastUserMsgRef = useRef<HTMLDivElement>(null);
-  const prevMessageCountRef = useRef(0);
+  const spacerRef = useRef<HTMLDivElement>(null);
+  const lastAnchoredUserMessageIdRef = useRef<string | null>(null);
+  const hasMountedRef = useRef(false);
+  const spacerHeightRef = useRef(0);
 
-  // 새 메시지 전송 시 → 마지막 사용자 메시지를 뷰포트 상단으로 스크롤
-  // (Gemini/ChatGPT 스타일: 사용자 메시지가 위에, 아래 빈 공간에 AI 응답이 채워짐)
-  useEffect(() => {
-    const prevCount = prevMessageCountRef.current;
-    prevMessageCountRef.current = messages.length;
+  // ── 조정 가능한 상수 ──
+  // USER_MESSAGE_TOP_GAP: 사용자 메시지가 스크롤 컨테이너 상단에서 떨어지는 간격(px)
+  // MIN_BOTTOM_SPACER: 콘텐츠와 입력창 사이의 최소 여백(px)
+  const USER_MESSAGE_TOP_GAP = 32;
+  const MIN_BOTTOM_SPACER = 32;
 
-    // 메시지가 새로 추가된 경우에만 스크롤
-    if (messages.length > prevCount && lastUserMsgRef.current) {
-      lastUserMsgRef.current.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
+  /** spacer 높이를 DOM에 직접 반영 (React 리렌더 없이) */
+  const setSpacerHeight = (h: number) => {
+    spacerHeightRef.current = h;
+    if (spacerRef.current) spacerRef.current.style.height = `${h}px`;
+  };
+
+  useLayoutEffect(() => {
+    if (!scrollRef.current) return;
+
+    const lastUserMessage = [...messages]
+      .reverse()
+      .find((m) => m.role === "user");
+    if (!lastUserMessage || !lastUserMsgRef.current) return;
+
+    const hasStreamingAssistant = messages.some(
+      (m) => m.role === "assistant" && !!m.isStreaming,
+    );
+
+    // 첫 마운트에서 기존 히스토리만 있는 경우에는 자동 점프를 막고,
+    // 첫 전송(assistant isStreaming) 시에는 아래 신규 사용자 메시지 분기로 진행
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      setSpacerHeight(MIN_BOTTOM_SPACER);
+      if (!hasStreamingAssistant) {
+        lastAnchoredUserMessageIdRef.current = lastUserMessage.id;
+        return;
+      }
     }
-  }, [messages.length]);
+
+    const container = scrollRef.current;
+    const isNewUserMessage =
+      lastAnchoredUserMessageIdRef.current !== lastUserMessage.id;
+
+    // 사용자 메시지를 상단 32px 위치에 놓기 위해 필요한 scrollTop
+    const targetScrollTop = Math.max(
+      lastUserMsgRef.current.offsetTop - USER_MESSAGE_TOP_GAP,
+      0,
+    );
+    // 현재 spacer를 제외한 순수 콘텐츠 높이
+    const contentHeight = container.scrollHeight - spacerHeightRef.current;
+
+    if (isNewUserMessage) {
+      // ── 새 사용자 메시지: 상단 앵커 ──
+      // 올바른 공식: targetScrollTop까지 스크롤하려면
+      // scrollHeight - clientHeight >= targetScrollTop 이어야 하므로
+      // spacer >= targetScrollTop + clientHeight - contentHeight
+      lastAnchoredUserMessageIdRef.current = lastUserMessage.id;
+      const neededSpacer = Math.max(
+        targetScrollTop + container.clientHeight - contentHeight,
+        MIN_BOTTOM_SPACER,
+      );
+
+      setSpacerHeight(neededSpacer);
+
+      // DOM 직접 변경 → reflow → scrollHeight 즉시 반영
+      const maxScrollTop = Math.max(
+        container.scrollHeight - container.clientHeight,
+        0,
+      );
+      container.scrollTo({
+        top: Math.min(targetScrollTop, maxScrollTop),
+        behavior: "smooth",
+      });
+    } else if (hasStreamingAssistant) {
+      // ── AI 스트리밍 중: spacer 자동 축소 + 하단 따라가기 ──
+      // 콘텐츠가 늘어남에 따라 spacer를 줄여 과도한 여백 제거
+      const optimalSpacer = Math.max(
+        targetScrollTop + container.clientHeight - contentHeight,
+        MIN_BOTTOM_SPACER,
+      );
+
+      setSpacerHeight(optimalSpacer);
+    }
+  }, [messages]);
+
+  // 대화 초기화 시 spacer 리셋
+  useEffect(() => {
+    if (messages.length === 0) {
+      setSpacerHeight(MIN_BOTTOM_SPACER);
+    }
+  }, [messages]);
 
   if (messages.length === 0) {
     return (
@@ -108,13 +184,12 @@ export const ChatMessages = ({ messages }: ChatMessagesProps) => {
   return (
     <div
       ref={scrollRef}
-      className="flex flex-1 justify-center overflow-x-hidden overflow-y-auto"
+      className="relative flex h-full justify-center overflow-x-hidden overflow-y-auto"
     >
       {/* 가운데 정렬 컨테이너 - ChatInput과 동일한 max-width */}
       <div className="w-full max-w-[660px] min-w-[270px] px-[16px] pt-[40px]">
         {messages.map((message, index) => {
           const prevMessage = messages[index - 1];
-          // 이전 메시지가 AI이고 현재가 사용자면 묶음 간 간격 (20px), 아니면 기본 간격 (12px)
           const isNewGroup =
             prevMessage?.role === "assistant" && message.role === "user";
           const marginTop =
@@ -139,8 +214,10 @@ export const ChatMessages = ({ messages }: ChatMessagesProps) => {
             </div>
           );
         })}
-        {/* 하단 여백 — 사용자 메시지가 상단에 위치할 수 있도록 충분한 빈 공간 확보 */}
-        <div className="min-h-[80vh] shrink-0" />
+        <div
+          ref={spacerRef}
+          className="shrink-0"
+        />
       </div>
     </div>
   );

--- a/src/features/chat/components/rightpanel/ChatMessages.tsx
+++ b/src/features/chat/components/rightpanel/ChatMessages.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useLayoutEffect } from "react";
+import { useRef, useEffect, useLayoutEffect, useCallback } from "react";
 import {
   ProfileIcon,
   SubscriptionIcon,
@@ -11,6 +11,12 @@ import type { ChatMessage } from "../../types/chat_types";
 interface ChatMessagesProps {
   messages: ChatMessage[];
 }
+
+// ── 조정 가능한 상수 ──
+// USER_MESSAGE_TOP_GAP: 사용자 메시지가 스크롤 컨테이너 상단에서 떨어지는 간격(px)
+// MIN_BOTTOM_SPACER: 콘텐츠와 입력창 사이의 최소 여백(px)
+const USER_MESSAGE_TOP_GAP = 32;
+const MIN_BOTTOM_SPACER = 32;
 
 // 사용자 메시지 컴포넌트
 const UserMessage = ({ message }: { message: ChatMessage }) => (
@@ -76,24 +82,23 @@ export const ChatMessages = ({ messages }: ChatMessagesProps) => {
   const hasMountedRef = useRef(false);
   const spacerHeightRef = useRef(0);
 
-  // ── 조정 가능한 상수 ──
-  // USER_MESSAGE_TOP_GAP: 사용자 메시지가 스크롤 컨테이너 상단에서 떨어지는 간격(px)
-  // MIN_BOTTOM_SPACER: 콘텐츠와 입력창 사이의 최소 여백(px)
-  const USER_MESSAGE_TOP_GAP = 32;
-  const MIN_BOTTOM_SPACER = 32;
-
   /** spacer 높이를 DOM에 직접 반영 (React 리렌더 없이) */
-  const setSpacerHeight = (h: number) => {
+  const setSpacerHeight = useCallback((h: number) => {
     spacerHeightRef.current = h;
     if (spacerRef.current) spacerRef.current.style.height = `${h}px`;
-  };
+  }, []);
 
   useLayoutEffect(() => {
     if (!scrollRef.current) return;
 
-    const lastUserMessage = [...messages]
-      .reverse()
-      .find((m) => m.role === "user");
+    let lastUserMessage: ChatMessage | undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        lastUserMessage = messages[i];
+        break;
+      }
+    }
+
     if (!lastUserMessage || !lastUserMsgRef.current) return;
 
     const hasStreamingAssistant = messages.some(
@@ -146,7 +151,7 @@ export const ChatMessages = ({ messages }: ChatMessagesProps) => {
         behavior: "smooth",
       });
     } else if (hasStreamingAssistant) {
-      // ── AI 스트리밍 중: spacer 자동 축소 + 하단 따라가기 ──
+      // ── AI 스트리밍 중: spacer 자동 축소 ──
       // 콘텐츠가 늘어남에 따라 spacer를 줄여 과도한 여백 제거
       const optimalSpacer = Math.max(
         targetScrollTop + container.clientHeight - contentHeight,
@@ -155,14 +160,17 @@ export const ChatMessages = ({ messages }: ChatMessagesProps) => {
 
       setSpacerHeight(optimalSpacer);
     }
-  }, [messages]);
+  }, [messages, setSpacerHeight]);
 
-  // 대화 초기화 시 spacer 리셋
+  // 대화 초기화 시: mount/anchor/spacer 상태를 모두 리셋
   useEffect(() => {
-    if (messages.length === 0) {
-      setSpacerHeight(MIN_BOTTOM_SPACER);
-    }
-  }, [messages]);
+    if (messages.length !== 0) return;
+
+    hasMountedRef.current = false;
+    lastAnchoredUserMessageIdRef.current = null;
+    spacerHeightRef.current = MIN_BOTTOM_SPACER;
+    setSpacerHeight(MIN_BOTTOM_SPACER);
+  }, [messages.length, setSpacerHeight]);
 
   if (messages.length === 0) {
     return (

--- a/src/features/chat/components/rightpanel/RightPanel.tsx
+++ b/src/features/chat/components/rightpanel/RightPanel.tsx
@@ -22,11 +22,10 @@ export const RightPanel = ({
 }: RightPanelProps) => {
   return (
     <div className="flex h-full flex-col bg-[#F1F4F8]">
-      {/* 메시지 + 입력창 컨테이너 (가운데 정렬) */}
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        {/* 메시지 영역 */}
+      {/* 메시지 영역 */}
+      <div className="min-h-0 flex-1 overflow-hidden">
         {isLoading ? (
-          <div className="flex flex-1 items-center justify-center text-gray-400">
+          <div className="flex h-full items-center justify-center text-gray-400">
             <div className="flex flex-col items-center gap-3">
               <LoadingSpinner size={50} />
               <span className="text-sm">대화를 불러오는 중...</span>
@@ -35,15 +34,15 @@ export const RightPanel = ({
         ) : (
           <ChatMessages messages={messages} />
         )}
+      </div>
 
-        {/* 입력창 - 가운데 정렬 */}
-        <div className="flex shrink-0 justify-center px-[16px] pb-[20px]">
-          <ChatInput
-            noteId={noteId}
-            onSend={onSend}
-            isSending={isSending}
-          />
-        </div>
+      {/* 입력 영역 */}
+      <div className="flex shrink-0 justify-center px-[16px] pb-[20px]">
+        <ChatInput
+          noteId={noteId}
+          onSend={onSend}
+          isSending={isSending}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #206 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

사용자 메시지 상단 앵커 고정 로직 개선
- 사용자 전송 시 마지막 사용자 메시지를 항상 상단 기준 위치(32px)에 맞추도록 보정
- 큰 화면/작은 화면 모두에서 동일하게 동작하도록 뷰포트 높이 기반 계산 적용

하단 여백(spacer) 계산식 교체
- 기존 과소 계산 공식을 제거하고, 실제 목표 스크롤 가능 범위를 만족하는 공식으로 변경
- 짧은 대화/초기 대화에서도 앵커 실패가 발생하지 않도록 수정

스크롤 타이밍 구조 단순화

- state 기반 2단계(pending) 스크롤 구조를 제거
- ref + DOM 직접 반영 방식으로 변경하여 리렌더 타이밍 경쟁 이슈 및 흔들림 감소

첫 전송 예외 처리 수정

- 기존에는 첫 전송에서 앵커 스크롤이 건너뛰어졌는데, 이제 첫 전송도 동일한 앵커 규칙 적용
- 기존 히스토리 진입 시 자동 점프 방지 동작은 유지
UX 정책 유지

- AI 답변과 입력창 사이 최소 간격 32px 유지
- 과도한 하단 여백은 스트리밍 진행에 따라 자연스럽게 축소
- 스크롤이 생겨도 자동 하단 추적은 강제하지 않음

## 📸 스크린샷


https://github.com/user-attachments/assets/794b4ea4-7ad8-4b89-bef8-becf65fcfd31



## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 채팅 메시지 스크롤이 보다 정교하게 동작하도록 개선(사용자 메시지 고정, 스트리밍 시 동작 분리).
  * 하단 여백(스페이서) 조정으로 메시지 정렬과 성장 처리 향상.
  * 대화 초기화 시 스크롤/여백 상태 리셋.
  * 채팅 패널 레이아웃 단순화로 높이·정렬 안정성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->