### PR TITLE
Fix(#210): 새로고침 시 mentionedAssets 기반 첨부 이미지 복원

### DIFF
--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -14,7 +14,7 @@ import {
 } from "@/features/assets/api/assetApi";
 import { resolveUploadMimeType } from "@/features/assets/utils/fileValidation";
 import type { ChatSendData } from "@/features/editor/components/ChatInput";
-import type { ConversationInfo } from "@/features/notes/api/notes_types";
+import type { ConversationInfo, AssetInfo } from "@/features/notes/api/notes_types";
 import type { FirstMessageState } from "@/pages/hooks/useHomeSend";
 import type { ChatMessage, MessageAttachment } from "../types/chat_types";
 import { creditKeys } from "@/features/settings/hooks/useCredit";
@@ -26,15 +26,39 @@ type PendingAttachment = ChatSendData["attachments"][number];
 /** 서버 ConversationInfo[] → ChatMessage[] 변환 */
 const convertConversations = (
   conversations: ConversationInfo[],
-): ChatMessage[] =>
-  conversations.flatMap((conv) => {
+  assets: AssetInfo[],
+): ChatMessage[] => {
+  const assetMap = new Map(assets.map((a) => [a.assetId, a]));
+
+  return conversations.flatMap((conv) => {
     const messages: ChatMessage[] = [];
+
+    // mentionedAssets → MessageAttachment[] 복원
+    const mentioned = conv.userMessage.mentionedAssets ?? [];
+    const attachments: MessageAttachment[] | undefined =
+      mentioned.length > 0
+        ? mentioned
+            .map((ma) => {
+              const asset = assetMap.get(ma.assetId);
+              const isImage = asset?.fileType?.toUpperCase() === "IMAGE";
+              const mimeType = isImage ? "image/png" : (asset?.fileType ?? "application/octet-stream");
+              return {
+                name: ma.fileName,
+                mimeType,
+                size: asset?.fileSize ?? 0,
+                previewUrl: isImage
+                  ? (asset?.thumbnailUrl ?? undefined)
+                  : undefined,
+              };
+            })
+        : undefined;
 
     // 사용자 메시지
     messages.push({
       id: `msg-${conv.userMessage.messageId}`,
       role: "user" as const,
       content: conv.userMessage.content,
+      attachments,
     });
 
     // AI 메시지 (빈 내용이면 건너뛰기)
@@ -59,6 +83,7 @@ const convertConversations = (
 
     return messages;
   });
+};
 
 /**
  * 채팅 메시지 상태 관리 훅
@@ -167,7 +192,7 @@ export const useChatMessages = () => {
   useEffect(() => {
     if (noteDetail?.conversations && !hasFirstMessage) {
       const reversed = [...noteDetail.conversations].reverse();
-      const serverMessages = convertConversations(reversed);
+      const serverMessages = convertConversations(reversed, noteDetail.assets ?? []);
 
       setMessages((prev) => {
         const serverIds = new Set(serverMessages.map((m) => m.id));


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #210 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `useChatMessages.ts`
  - `convertConversations`에 `assets: AssetInfo[]` 파라미터 추가
  - `assetId -> AssetInfo` 맵 생성 후 `mentionedAssets -> attachments` 복원
  - 이미지(`fileType === "IMAGE"`)는 `thumbnailUrl`을 `previewUrl`로 설정
  - AssetInfo.fileType이 MIME이 아니라 카테고리이므로 이미지 판별 로직 수정
  - 호출부에서 `convertConversations(reversed, noteDetail.assets ?? [])`로 assets 전달

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 메시지에서 첨부 파일이 올바르게 복원되도록 개선했습니다.
  * AI 메시지 처리의 안정성을 향상시켰으며, 오류 상황에서 더 나은 처리를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->