### PR TITLE
Fix(#212): 검색 결과 타입 정합화 및 하이라이트 기반 프리뷰 표시

### DIFF
--- a/src/features/editor/types/editor_types.ts
+++ b/src/features/editor/types/editor_types.ts
@@ -220,20 +220,11 @@ export interface MentionedFile {
   fileName: string;
 }
 
-/** 검색 결과 메시지 정보 (NoteDetail의 MessageInfo와 동일 구조) */
+/** 검색 결과 메시지 정보 (백엔드 MessageInfo 구조) */
 export interface SearchMessageInfo {
-  messageId: number;
-  content: string;
-  mentionedAssets: { assetId: number; fileName: string }[];
-  mentionedTools: string[];
-  usedTools: string[];
-  generatedFiles: {
-    fileId: number;
-    fileName: string;
-    fileType: string;
-    downloadUrl: string;
-  }[];
-  createdAt: string;
+  text: string;
+  preview: string;
+  highlight: string;
 }
 
 /** 대화 검색 결과 항목 */

--- a/src/features/search/components/SearchModal.tsx
+++ b/src/features/search/components/SearchModal.tsx
@@ -118,9 +118,10 @@ const SearchModal = ({ isOpen, onClose }: SearchModalProps) => {
     if (!searchData?.conversations) return [];
     return groupItemsByDate(
       searchData.conversations.map((conv) => {
-        const userMessageText = conv.userMessage?.content ?? "";
-        const assistantMessageText = conv.assistantMessage?.content ?? "";
-        const previewText = userMessageText || assistantMessageText;
+        // highlight가 있으면 우선 사용 (검색어 주변 ...텍스트... 형태)
+        const userHighlight = conv.userMessage?.highlight;
+        const assistantHighlight = conv.assistantMessage?.highlight;
+        const previewText = userHighlight || assistantHighlight || "";
 
         return {
           dateStr: conv.createdAt,
@@ -128,10 +129,7 @@ const SearchModal = ({ isOpen, onClose }: SearchModalProps) => {
             id: String(conv.conversationId),
             title: conv.noteTitle,
             noteId: conv.noteId,
-            preview:
-              previewText.length > 80
-                ? previewText.slice(0, 80) + "…"
-                : previewText,
+            preview: previewText || undefined,
           },
         };
       }),


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #212 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- SearchMessageInfo 타입을 백엔드 MessageInfo({ text, preview, highlight })와 정합화
- SearchModal에서 잘못된 필드 접근 제거
  - `conv.userMessage?.content` → `conv.userMessage?.highlight` 우선 사용
- highlight 텍스트를 preview로 그대로 사용하여 검색어 주변 문맥이 보이도록 개선
  - (HighlightText 컴포넌트가 키워드 강조 처리)

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 백엔드 highlight(…검색어 주변… 형태)를 프리뷰로 활용하여 UX 개선