### PR TITLE
Fix(#219): 뷰어에 드래그앤드롭 버그 수정 

### DIFF
--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -140,6 +140,7 @@ export const FileRenderer = ({
             src={fileUrl}
             alt={fileName}
             className="h-full w-full object-contain"
+            draggable={false}
           />
         </div>
       </div>
@@ -183,6 +184,7 @@ export const FileRenderer = ({
             <canvas
               ref={canvasRef}
               className="block bg-white"
+              draggable={false}
             />
           </div>
         </div>

--- a/src/features/storage/pages/StoragePage.tsx
+++ b/src/features/storage/pages/StoragePage.tsx
@@ -105,9 +105,6 @@ export const StoragePage = () => {
               <EmptyState
                 message="업로드된 파일이 없습니다"
                 description="새로운 파일을 업로드하여 저장소를 채워보세요."
-                // TODO: Add upload action when available
-                // actionLabel="파일 업로드하기"
-                // onAction={() => {}}
               />
             )}
           </div>

--- a/src/shared/hooks/useFileUpload.tsx
+++ b/src/shared/hooks/useFileUpload.tsx
@@ -38,6 +38,12 @@ export const useFileUpload = (
   const onDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+
+    // 파일 드래그가 아니면 무시 (텍스트 선택, 내부 이미지 드래그 등)
+    if (!e.dataTransfer.types.includes("Files")) {
+      return;
+    }
+
     dragCounter.current += 1;
     if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
       setIsDragging(true);
@@ -47,6 +53,12 @@ export const useFileUpload = (
   const onDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+
+    // 파일 드래그가 아니면 무시 (Enter와 대칭 유지)
+    if (!e.dataTransfer.types.includes("Files")) {
+      return;
+    }
+
     dragCounter.current -= 1;
     if (dragCounter.current === 0) {
       setIsDragging(false);


### PR DESCRIPTION
## 📌 관련 이슈
Closes #219 

## 🏷️ PR 타입

- [ ]  ✨ 기능 추가 (Feature)
- [x]  🐛 버그 수정 (Bug Fix)
- [ ]  ♻️ 리팩토링 (Refactoring)
- [ ]  📝 문서 수정 (Documentation)
- [ ]  🎨 스타일 변경 (Style)
- [ ]  ✅ 테스트 추가 (Test)

## 📝 작업 내용
- 뷰어 내부의 이미지나 PDF 캔버스 드래그 시, 파일 업로드 오버레이가 불필요하게 노출되는 문제를 해결
 `FileRenderer.tsx`: 이미지(img)와 PDF 캔버스(canvas) 요소에 draggable={false} 속성을 추가하여 내부 요소 드래그를 방지했다.
 `useFileUpload.tsx`: onDragEnter, onDragLeave 핸들러에서 드래그 이벤트가 "Files" 타입을 포함하는지 확인하는 로직을 추가했다.
- 파일 드래그가 아닌 경우(텍스트 선택, 내부 이미지 드래그 등)에는 드래그 상태(isDragging)를 변경하지 않도록 하여 오버레이 깜빡임 및 오작동 방지.
- dragCounter가 정확하게 동작하도록 진입(Enter)와 이탈(Leave) 로직의 대칭성을 맞추기.

## 📸 스크린샷
뷰어에 보이는 파일 위에 드래그 앤 드롭 하려해도 안 됨.

https://github.com/user-attachments/assets/9c6d8245-73a1-44d8-bb56-172d46535f6f


## ✅ 체크리스트
- [x]  코드 리뷰를 받을 준비가 완료되었습니다
- [ ]  테스트를 작성하고 모두 통과했습니다 (수동 테스트 완료)
- [ ]  문서를 업데이트했습니다 (필요한 경우)
- [ ]  코드 스타일 가이드를 준수했습니다
- [ ]  셀프 리뷰를 완료했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이미지 뷰어와 PDF 뷰어에서 이미지/캔버스의 드래그 동작을 차단해 의도치 않은 드래그 상호작용을 방지
  * 파일 업로드 드래그 감지 로직을 개선하여 실제 파일 드래그에 대해서만 드래그 상태가 변경되도록 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->