### PR TITLE
Fix(#223): 노트 목록 페이지 -> 제목 수정 아이콘 변경

### DIFF
--- a/src/shared/components/icons/NotesIcons.tsx
+++ b/src/shared/components/icons/NotesIcons.tsx
@@ -1,16 +1,12 @@
 import type { SVGProps } from "react";
 
-export const NoteEditIcon = ({
-  className,
-  ...props
-}: SVGProps<SVGSVGElement>) => (
+export const NoteEditIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     width="18"
     height="18"
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    className={`text-[#6B7280] transition-colors hover:text-[#2A6AFF] ${className ?? ""}`}
     {...props}
   >
     <path

--- a/src/shared/components/icons/NotesIcons.tsx
+++ b/src/shared/components/icons/NotesIcons.tsx
@@ -1,25 +1,35 @@
 import type { SVGProps } from "react";
 
-export const NoteEditIcon = (props: SVGProps<SVGSVGElement>) => (
+export const NoteEditIcon = ({
+  className,
+  ...props
+}: SVGProps<SVGSVGElement>) => (
   <svg
-    viewBox="0 0 24 24"
+    width="18"
+    height="18"
+    viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    className={`text-[#6B7280] transition-colors hover:text-[#2A6AFF] ${className ?? ""}`}
     {...props}
   >
     <path
-      d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Z"
+      d="M6 11L2.08322 12.5667C1.67507 12.73 1.27003 12.3249 1.43329 11.9168L3 8"
       stroke="currentColor"
-      strokeWidth="1.8"
       strokeLinecap="round"
-      strokeLinejoin="round"
     />
     <path
-      d="M14.06 4.19 17.81 7.94"
+      d="M3 8L6 11"
       stroke="currentColor"
-      strokeWidth="1.8"
+    />
+    <path
+      d="M3 8.69231L9.9852 1.70711C10.3757 1.31658 11.0089 1.31658 11.3994 1.70711L12.2929 2.60059C12.6834 2.99111 12.6834 3.62427 12.2929 4.0148L5.30769 11"
+      stroke="currentColor"
+    />
+    <path
+      d="M12 13H9"
+      stroke="currentColor"
       strokeLinecap="round"
-      strokeLinejoin="round"
     />
   </svg>
 );


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #223 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [x] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 노트 목록 페이지의 각 노트에서 제목 수정할 수 있는 아이콘이 직관적이지 않음
- 연필 모양으로 개선하여 바꿈

## 📸 스크린샷

<img width="778" height="660" alt="image" src="https://github.com/user-attachments/assets/5e565714-00d2-4730-b137-084d91e77229" />

- 기본 모양

<img width="798" height="662" alt="image" src="https://github.com/user-attachments/assets/a3cd25ad-83cd-41e7-9805-9ee870e0fff3" />

- hover 모습


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **스타일**
  * 노트 편집 아이콘의 시각적 디자인이 업데이트되었습니다. 아이콘 크기와 모양이 개선되어 더 명확한 표시를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->