### PR TITLE
[Feat] 첫 질문 기반 AI 노트 제목 생성 API 호출 로직 추가

### DIFF
--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -6,6 +6,7 @@ import {
   parseSSEStream,
 } from "@/features/editor/api/editor_api";
 import { useNoteDetail, noteKeys } from "@/features/notes/hooks/useNotes";
+import { generateNoteTitle } from "@/features/notes/api/notes_api";
 import { uploadAttachments } from "@/features/assets/utils/upload_attachments";
 import {
   getUploadUrl,
@@ -470,6 +471,18 @@ export const useChatMessages = () => {
           },
           { isStream: true, signal },
         );
+
+        // 제목 생성을 스트리밍과 병렬로 백그라운드 실행 (실패해도 기존 제목 유지)
+        void generateNoteTitle(Number(noteId), { text: firstMessageData.text })
+          .then(() => {
+            void queryClient.invalidateQueries({
+              queryKey: ["notes", "detail", noteId],
+            });
+            void queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+          })
+          .catch(() => {
+            // 실패 시 날짜/시간 제목 유지, 에러 표시 안함
+          });
 
         await processStream(response, tempAssistantMsgId, signal);
 

--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -474,9 +474,10 @@ export const useChatMessages = () => {
 
         // 제목 생성을 스트리밍과 병렬로 백그라운드 실행 (실패해도 기존 제목 유지)
         void generateNoteTitle(Number(noteId), { text: firstMessageData.text })
-          .then(() => {
+          .then((response) => {
+            if (!response.isSuccess) return;
             void queryClient.invalidateQueries({
-              queryKey: ["notes", "detail", noteId],
+              queryKey: noteKeys.detail(String(noteId)),
             });
             void queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
           })
@@ -494,9 +495,6 @@ export const useChatMessages = () => {
         }
 
         // 첫 대화 성공 후 노트 상세 refetch → AI가 갱신한 제목 반영
-        queryClient.invalidateQueries({
-          queryKey: ["notes", "detail", noteId],
-        });
         // 크레딧 잔액 최신화 (대화 생성 시 서버에서 자동 차감)
         queryClient.invalidateQueries({ queryKey: creditKeys.all });
         queryClient.invalidateQueries({ queryKey: userKeys.profile() });
@@ -641,7 +639,7 @@ export const useChatMessages = () => {
         await processStream(response, tempAssistantMsgId, signal);
 
         queryClient.invalidateQueries({
-          queryKey: ["notes", "detail", noteId],
+          queryKey: noteKeys.detail(String(nId)),
         });
         // 크레딧 잔액 최신화 (대화 생성 시 서버에서 자동 차감)
         queryClient.invalidateQueries({ queryKey: creditKeys.all });

--- a/src/features/notes/api/notes_api.ts
+++ b/src/features/notes/api/notes_api.ts
@@ -7,6 +7,7 @@ import type {
   CreateNoteResponse,
   UpdateNoteTitleRequest,
   UpdateNoteTitleResponse,
+  GenerateTitleRequest,
   NoteDetailParams,
   NoteDetailResponse,
   DeleteNotesBulkResult,
@@ -69,6 +70,18 @@ export const updateNoteTitle = async (
 ): Promise<ApiResponse<UpdateNoteTitleResponse>> => {
   const response = await apiClient.patch<ApiResponse<UpdateNoteTitleResponse>>(
     `${NOTES_BASE}/${noteId}`,
+    data,
+  );
+  return response.data;
+};
+
+// 첫 질문 기반 AI 노트 제목 생성
+export const generateNoteTitle = async (
+  noteId: number,
+  data: GenerateTitleRequest,
+): Promise<ApiResponse<UpdateNoteTitleResponse>> => {
+  const response = await apiClient.post<ApiResponse<UpdateNoteTitleResponse>>(
+    `${NOTES_BASE}/${noteId}/generate-title`,
     data,
   );
   return response.data;

--- a/src/features/notes/api/notes_types.ts
+++ b/src/features/notes/api/notes_types.ts
@@ -22,6 +22,11 @@ export interface UpdateNoteTitleRequest {
   title: string;
 }
 
+/** AI 노트 제목 생성 요청 */
+export interface GenerateTitleRequest {
+  text: string;
+}
+
 // ============================================================
 // 응답 (Response) 타입
 // ============================================================


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #229 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 첫 질문 전송 후 병렬로 노트 제목 생성 요청 (`generateNoteTitle` API 호출)
- 제목 생성 완료 후 사이드바 및 채팅 헤더 제목을 실시간 업데이트
- 제목 생성 실패 시 기존 제목 유지, 에러 표시하지 않음
- `SearchModal`에서 노트 제목을 실시간으로 갱신

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- `generateNoteTitle` 호출 후 제목 생성 성공 시 UI가 실시간으로 업데이트됩니다.
- 제목 생성 실패 시 기존 제목을 유지하며, 에러 메시지는 표시되지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 첫 메시지 전송 시 AI가 자동으로 노트 제목을 생성하도록 개선했습니다.
  * 제목 생성이 백그라운드에서 진행되어 채팅 흐름을 방해하지 않습니다.
  * 생성된 제목으로 노트 목록이 자동으로 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->