### PR TITLE
Style(#232): 사이드바 유저 호버 시 효과 

### DIFF
--- a/src/features/sidebar/components/SidebarProfile.tsx
+++ b/src/features/sidebar/components/SidebarProfile.tsx
@@ -6,6 +6,7 @@ import {
   PaperIcon,
 } from "../../../shared/components/icons/SidebarIcons";
 
+import { useState } from "react";
 import { useAuthStore } from "../../auth/store/auth_store";
 import { useNoteList } from "@/features/notes/hooks/useNotes";
 import { useMyProfile } from "@/features/settings/hooks/useUser";
@@ -27,6 +28,7 @@ export const SidebarProfile = ({
   onUpgradeClick,
   onSettingsClick,
 }: SidebarProfileProps) => {
+  const [isUserIconHovered, setIsUserIconHovered] = useState(false);
   const authUser = useAuthStore((state) => state.user);
   const { data: profile } = useMyProfile();
   const { data: noteListData } = useNoteList({
@@ -153,15 +155,20 @@ export const SidebarProfile = ({
           {creditTotal}
         </span>
       </div>
-      <UserIcon
+      <div
+        className="cursor-pointer"
+        onMouseEnter={() => setIsUserIconHovered(true)}
+        onMouseLeave={() => setIsUserIconHovered(false)}
         onClick={(e) => {
           e.stopPropagation();
           onSettingsClick();
         }}
-        size={40}
-        color="currentColor"
-        className="cursor-pointer text-[#2A6AFF] transition-colors hover:text-[#85B0FF]"
-      />
+      >
+        <UserIcon
+          size={40}
+          color={isUserIconHovered ? "#85B0FF" : "#2A6AFF"}
+        />
+      </div>
     </div>
   );
 };

--- a/src/features/sidebar/components/SidebarProfile.tsx
+++ b/src/features/sidebar/components/SidebarProfile.tsx
@@ -155,8 +155,9 @@ export const SidebarProfile = ({
           {creditTotal}
         </span>
       </div>
-      <div
-        className="cursor-pointer"
+      <button
+        type="button"
+        className="cursor-pointer border-none bg-transparent p-0"
         onMouseEnter={() => setIsUserIconHovered(true)}
         onMouseLeave={() => setIsUserIconHovered(false)}
         onClick={(e) => {
@@ -168,7 +169,7 @@ export const SidebarProfile = ({
           size={40}
           color={isUserIconHovered ? "#85B0FF" : "#2A6AFF"}
         />
-      </div>
+      </button>
     </div>
   );
 };

--- a/src/features/sidebar/components/SidebarProfile.tsx
+++ b/src/features/sidebar/components/SidebarProfile.tsx
@@ -159,7 +159,8 @@ export const SidebarProfile = ({
           onSettingsClick();
         }}
         size={40}
-        className="cursor-pointer"
+        color="currentColor"
+        className="cursor-pointer text-[#2A6AFF] transition-colors hover:text-[#85B0FF]"
       />
     </div>
   );


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #232 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 사이드바에서 유저 아이콘 호버시 아이콘 색상 연해지는 효과 추가

## 📸 스크린샷


https://github.com/user-attachments/assets/ef5a1d66-1eb0-43f1-9735-1a5c39532468



## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 축소된 사이드바의 프로필 아이콘에 마우스 호버 시 색상 전환과 인터랙티브한 호버 동작을 추가했습니다.
  * 확장된 뷰의 사용자 영역에도 호버 가능한 래퍼를 적용해 일관된 피드백을 제공하며, 클릭하여 설정을 여는 기존 동작은 유지됩니다.
  * 호버 동작은 컴포넌트 내에서 관리되어 사용자 경험이 보다 직관적으로 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->