### PR TITLE
Fix(#237): 노트 목록 페이지 중앙 정렬, 저장소 디테일 수정, 전반적인 페이지 반응형 수정

### DIFF
--- a/src/features/notes/components/NoteCard.tsx
+++ b/src/features/notes/components/NoteCard.tsx
@@ -161,7 +161,7 @@ export const NoteCard = ({
         aria-label={`${note.title} ${isSelected ? "선택됨" : "선택 안됨"}`}
         role="button"
         tabIndex={0}
-        className={`group relative flex h-[229px] w-[271px] cursor-pointer flex-col rounded-[12px] text-left transition-colors transition-transform hover:scale-[1.02] ${
+        className={`group relative flex h-[204px] w-full cursor-pointer flex-col rounded-[12px] text-left transition-colors transition-transform hover:scale-[1.02] ${
           isSelected
             ? "border-[1.5px] border-[#2A6AFF] bg-[#F1F4F8]"
             : "border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] hover:bg-[#E8ECF1]"
@@ -192,7 +192,7 @@ export const NoteCard = ({
       role="link"
       tabIndex={0}
       aria-label={`${note.title} 노트로 이동`}
-      className="group flex h-[229px] w-[271px] cursor-pointer flex-col rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] transition-colors transition-transform hover:scale-[1.02] hover:bg-[#E8ECF1]"
+      className="group flex h-[204px] w-full cursor-pointer flex-col rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] transition-colors transition-transform hover:scale-[1.02] hover:bg-[#E8ECF1]"
     >
       {noteContent}
     </div>
@@ -207,15 +207,15 @@ function NoteThumbnail({
   title: string;
 }) {
   return (
-    <div className="h-[149px] w-full overflow-hidden rounded-t-[12px] bg-[#E8ECF1]">
+    <div className="h-[131px] w-full overflow-hidden rounded-t-[12px] bg-[#E8ECF1]">
       {thumbnailUrl ? (
         <img
           src={thumbnailUrl}
           alt={title}
           loading="lazy"
           decoding="async"
-          width={271}
-          height={149}
+          width={240}
+          height={131}
           className="h-full w-full object-cover"
         />
       ) : (
@@ -255,7 +255,7 @@ function NoteInfo({
   onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
 }) {
   return (
-    <div className="flex h-[80px] w-full flex-col items-start justify-center rounded-b-[12px] border-t-[0.5px] border-[#D1D6DE] bg-white px-[16px] py-[8px]">
+    <div className="flex h-[73px] w-full flex-col items-start justify-center rounded-b-[12px] border-t-[0.5px] border-[#D1D6DE] bg-white px-[16px] py-[8px]">
       <div className="flex w-full flex-col gap-[8px]">
         <div className="flex w-full items-center justify-between gap-[8px]">
           {isEditing ? (

--- a/src/features/notes/components/NotesAddCard.tsx
+++ b/src/features/notes/components/NotesAddCard.tsx
@@ -8,7 +8,7 @@ import { PdfIcon } from "../../../shared/components/icons/HomepageInputIcons";
 export const NotesAddCard = () => (
   <Link
     to="/app/home"
-    className="group flex h-[229px] w-[271px] flex-col items-center justify-center rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] px-[97px] py-[70px] transition-colors hover:bg-[#E8ECF1]"
+    className="group flex h-[204px] w-full flex-col items-center justify-center rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-[#F1F4F8] transition-colors hover:bg-[#E8ECF1]"
   >
     <div className="mb-[8px] flex h-[60px] w-[60px] items-center justify-center rounded-[30px] bg-white p-[6px]">
       <PdfIcon

--- a/src/features/notes/components/NotesGrid.tsx
+++ b/src/features/notes/components/NotesGrid.tsx
@@ -27,7 +27,7 @@ export const NotesGrid = ({
 
   return (
     <div className="mt-[21px] flex justify-center">
-      <div className="grid w-full grid-cols-2 gap-[20px] lg:grid-cols-3">
+      <div className="3xl:grid-cols-5 grid w-full grid-cols-2 gap-[20px] lg:grid-cols-3 2xl:grid-cols-4">
         {showAddCard && <NotesAddCard />}
 
         {isLoading ? (

--- a/src/features/notes/components/NotesGrid.tsx
+++ b/src/features/notes/components/NotesGrid.tsx
@@ -26,8 +26,8 @@ export const NotesGrid = ({
   const placeholderCount = Math.max(0, totalSlots - usedSlots);
 
   return (
-    <div className="mt-[21px]">
-      <div className="grid grid-cols-[repeat(2,271px)] gap-[40px] min-[1340px]:grid-cols-[repeat(3,271px)]">
+    <div className="mt-[21px] flex justify-center">
+      <div className="grid w-full grid-cols-2 gap-[20px] lg:grid-cols-3">
         {showAddCard && <NotesAddCard />}
 
         {isLoading ? (
@@ -49,7 +49,7 @@ export const NotesGrid = ({
               <div
                 key={`placeholder-${index}`}
                 aria-hidden="true"
-                className="h-[229px] w-[271px] rounded-[12px] border-[0.5px] border-transparent bg-transparent"
+                className="h-[204px] w-full rounded-[12px] border-[0.5px] border-transparent bg-transparent"
               />
             ))}
           </>

--- a/src/features/notes/components/NotesHeader.tsx
+++ b/src/features/notes/components/NotesHeader.tsx
@@ -55,14 +55,16 @@ export const NotesHeader = ({
 
   return (
     <div className="w-full">
-      <div className="w-[582px] min-[1340px]:w-[893px]">
-        <div className="mb-[16px]">
-          <h1 className="text-[40px] leading-[52px] font-semibold tracking-[-0.008px] text-black">
+      <div className="mb-[23px] flex justify-center">
+        <div className="3xl:max-w-[1360px] w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
+          <h1 className="font-['Pretendard'] text-[40px] leading-[52px] font-semibold text-black">
             노트 목록
           </h1>
         </div>
+      </div>
 
-        <div className="w-full">
+      <div className="flex justify-center">
+        <div className="3xl:max-w-[1360px] w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-[8px]">
               <div

--- a/src/features/notes/pages/NotesPage.tsx
+++ b/src/features/notes/pages/NotesPage.tsx
@@ -57,7 +57,7 @@ export const NotesPage = () => {
 
   return (
     <div className="flex h-screen w-full flex-col overflow-y-auto bg-white pt-[97px] pb-20">
-      <div className="3xl:max-w-[1360px] mx-auto w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
+      <div className="mx-auto w-full max-w-[1680px]">
         <NotesHeader
           sortOrder={sortOrder}
           isSortDropdownOpen={isSortDropdownOpen}
@@ -72,23 +72,27 @@ export const NotesPage = () => {
           onDeleteClick={handleDeleteClick}
         />
 
-        <NotesGrid
-          notes={notes}
-          isLoading={isLoading}
-          isSelectMode={isSelectMode}
-          selectedIds={selectedIds}
-          onToggleSelection={toggleIdSelection}
-          showAddCard={currentPage === 0}
-          totalSlots={6}
-        />
+        <div className="flex justify-center">
+          <div className="3xl:max-w-[1360px] w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
+            <NotesGrid
+              notes={notes}
+              isLoading={isLoading}
+              isSelectMode={isSelectMode}
+              selectedIds={selectedIds}
+              onToggleSelection={toggleIdSelection}
+              showAddCard={currentPage === 0}
+              totalSlots={6}
+            />
 
-        <NotesPagination
-          pageInfo={pageInfo}
-          currentPage={currentPage}
-          onPreviousPage={handlePreviousPage}
-          onNextPage={handleNextPage}
-          onPageChange={setCurrentPage}
-        />
+            <NotesPagination
+              pageInfo={pageInfo}
+              currentPage={currentPage}
+              onPreviousPage={handlePreviousPage}
+              onNextPage={handleNextPage}
+              onPageChange={setCurrentPage}
+            />
+          </div>
+        </div>
       </div>
 
       {isDeleteModalOpen && (

--- a/src/features/sidebar/components/SidebarProfile.tsx
+++ b/src/features/sidebar/components/SidebarProfile.tsx
@@ -87,18 +87,18 @@ export const SidebarProfile = ({
           <button
             onClick={(e) => {
               e.stopPropagation();
-              if (authUser?.plan !== "Pro") {
+              if (planType !== "Pro") {
                 onUpgradeClick();
               }
             }}
             className={`flex h-[24px] w-[70px] cursor-pointer items-center justify-center rounded bg-[#2A6AFF] text-[12px] leading-none text-white transition-colors ${
-              authUser?.plan === "Pro"
+              planType === "Pro"
                 ? "cursor-default opacity-50"
                 : "hover:bg-[#2A6AFF]/50 active:bg-white active:text-black"
             }`}
-            disabled={authUser?.plan === "Pro"}
+            disabled={planType === "Pro"}
           >
-            {authUser?.plan === "Pro" ? "최고 플랜" : "업그레이드"}
+            {planType === "Pro" ? "최고 플랜" : "업그레이드"}
           </button>
         </div>
         <div className="flex items-center justify-between text-gray-500">

--- a/src/features/storage/components/StorageToolbar.tsx
+++ b/src/features/storage/components/StorageToolbar.tsx
@@ -105,7 +105,7 @@ export const StorageToolbar = ({
             fontStyle: "normal",
             fontWeight: 500,
             lineHeight: "20px",
-            alignSelf: "stretch",
+            alignSelf: "flex-end",
           }}
         >
           전체 용량

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -37,16 +37,16 @@ export const HomePage = () => {
       {/* 메인 홈 화면 - 한 화면을 꽉 채우는 구성 */}
       <div className="flex min-h-screen w-full flex-col items-center">
         <div className="flex w-full flex-1 flex-col justify-center px-5 pt-[100px]">
-          <div className="mx-auto flex w-full max-w-[920px] flex-col">
+          <div className="mx-auto flex w-full max-w-[920px] flex-col items-center lg:items-start">
             {/* 타이틀 */}
-            <div className="mb-8">
-              <h1 className="text-[40px] leading-[52px] font-semibold tracking-[-0.008px] text-black">
+            <div className="mb-8 w-full text-center lg:text-left">
+              <h1 className="text-[32px] leading-[42px] font-semibold tracking-[-0.008px] text-black sm:text-[40px] sm:leading-[52px]">
                 파일을 업로드하고 완벽한 해설을,
               </h1>
             </div>
 
             {/* 메인 입력 카드 */}
-            <div className="mb-10 flex gap-[40px]">
+            <div className="mb-10 flex w-full flex-col gap-6 lg:flex-row lg:gap-[40px]">
               <ViewerUploadCard
                 pdfUrl={pdfUrl}
                 fileName={fileName}
@@ -61,6 +61,7 @@ export const HomePage = () => {
               <ChatInput
                 onSend={handleSend}
                 isSending={isSending}
+                className="!max-w-none lg:!max-w-[660px]"
               />
             </div>
           </div>

--- a/src/pages/components/ViewerUploadCard.tsx
+++ b/src/pages/components/ViewerUploadCard.tsx
@@ -51,7 +51,7 @@ export const ViewerUploadCard = ({
     )}
 
     {pdfUrl ? (
-      <div className="group relative flex h-[160px] w-[220px] shrink-0 flex-col items-center overflow-hidden rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-all">
+      <div className="group relative flex h-[160px] w-full shrink-0 flex-col items-center overflow-hidden rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-all lg:w-[220px]">
         {/* 닫기 버튼 */}
         <button
           onClick={onRemove}
@@ -64,7 +64,7 @@ export const ViewerUploadCard = ({
         </button>
 
         {/* PDF/이미지 썸네일 */}
-        <div className="relative flex w-[160px] flex-1 items-center justify-center overflow-hidden">
+        <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden lg:w-[160px]">
           <div className="flex h-full w-full items-center justify-center">
             {fileName.toLowerCase().endsWith(".pdf") ? (
               <PdfPreview
@@ -96,7 +96,7 @@ export const ViewerUploadCard = ({
       <button
         onClick={onOpenExplorer}
         type="button"
-        className="group flex h-[160px] w-[220px] shrink-0 cursor-pointer flex-col items-center justify-center gap-[16px] rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white/40 px-[20px] py-[24px] shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-colors duration-700 hover:bg-[#2A6AFF33] active:bg-[#2A6AFF33]"
+        className="group flex h-[160px] w-full shrink-0 cursor-pointer flex-col items-center justify-center gap-[16px] rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white/40 px-[20px] py-[24px] shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-colors duration-700 hover:bg-[#2A6AFF33] active:bg-[#2A6AFF33] lg:w-[220px]"
       >
         <div>
           <PdfIcon size={56} />


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #237

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [x] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 노트 목록 페이지 중앙 정렬
- 저장소 디테일 수정
- 전반적인 페이지 반응형 수정

## 📸 스크린샷

<img width="3020" height="1650" alt="image" src="https://github.com/user-attachments/assets/7c4571a8-8390-4441-8a91-5b6f7a99a41e" />

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 노트 카드의 레이아웃을 더욱 컴팩트하게 조정하였습니다.
  * 반응형 디자인을 개선하여 다양한 화면 크기에 최적화되도록 업데이트하였습니다.
  * 페이지 헤더, 그리드, 업로드 카드의 정렬 및 간격을 정리하였습니다.
  * 모바일 화면에서의 사용성을 향상시키기 위해 레이아웃을 재구성하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->