### PR TITLE
[Refactor] Spring v2 스트리밍에 맞춰 프론트 코드 수정 및 FinalResponse 말풍선 처리 추가

### DIFF
--- a/src/features/chat/components/rightpanel/ChatMessages.tsx
+++ b/src/features/chat/components/rightpanel/ChatMessages.tsx
@@ -1,8 +1,9 @@
-import { useRef, useEffect, useLayoutEffect, useCallback } from "react";
+import { useRef, useEffect, useLayoutEffect, useCallback, useState } from "react";
 import {
   ProfileIcon,
   SubscriptionIcon,
 } from "@/shared/components/icons/SettingsIcons";
+import { SparkleIcon } from "@/shared/components/icons/SparkleIcon";
 import { MessageContent } from "./MessageContent";
 import { MessageAttachments } from "./MessageAttachments";
 import { ThinkingBar } from "./ThinkingBar";
@@ -11,6 +12,53 @@ import type { ChatMessage } from "../../types/chat_types";
 interface ChatMessagesProps {
   messages: ChatMessage[];
 }
+
+// FinalResponse 말풍선 대기 중 순환 메시지
+const FINAL_LOADING_MESSAGES = [
+  "마지막 요약정리중...",
+  "생각정리중...",
+  "진짜 답변 나오는중...",
+  "진짜 최종 답변 나오는중...",
+  "진짜 진짜 최종 답변 나오는중...",
+  "Proove it 하는중...",
+  "두쫀쿠 만드는중...",
+  "카다이프 구해오는중...",
+];
+
+/** FinalResponse 토큰 대기 중 로딩 바 (3초마다 메시지 순환) */
+const FinalResponseLoadingBar = () => {
+  const [index, setIndex] = useState(0);
+  const [isBlue, setIsBlue] = useState(true);
+
+  useEffect(() => {
+    const msgTimer = setInterval(() => {
+      setIndex((prev) => (prev + 1) % FINAL_LOADING_MESSAGES.length);
+    }, 3000);
+    const iconTimer = setInterval(() => {
+      setIsBlue((prev) => !prev);
+    }, 800);
+    return () => {
+      clearInterval(msgTimer);
+      clearInterval(iconTimer);
+    };
+  }, []);
+
+  return (
+    <div className="flex min-h-[30px] w-full items-center gap-[8px] overflow-hidden rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-[#E3E7ED] p-[10px]">
+      <SparkleIcon
+        size={24}
+        color={isBlue ? "#2A6AFF" : "#6B7280"}
+        className="shrink-0 transition-colors duration-300"
+      />
+      <div
+        key={index}
+        className="min-w-0 animate-in fade-in slide-in-from-bottom-1 fill-mode-both text-[14px] leading-[20px] font-medium text-[#6B7280] duration-300"
+      >
+        {FINAL_LOADING_MESSAGES[index]}
+      </div>
+    </div>
+  );
+};
 
 // ── 조정 가능한 상수 ──
 // USER_MESSAGE_TOP_GAP: 사용자 메시지가 스크롤 컨테이너 상단에서 떨어지는 간격(px)
@@ -63,7 +111,11 @@ const AssistantMessage = ({
       />
     </div>
     {isStreaming && !content ? (
-      <ThinkingBar statusText={statusText} />
+      statusText ? (
+        <ThinkingBar statusText={statusText} />
+      ) : (
+        <FinalResponseLoadingBar />
+      )
     ) : (
       <div className="w-full overflow-hidden rounded-[12px] border-[0.5px] border-[#D1D6DE] bg-white p-[10px]">
         <div className="text-sm leading-5 break-words text-gray-900">

--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -281,7 +281,7 @@ export const useChatMessages = () => {
           case "node.progress": {
             setMessages((prev) =>
               prev.map((m) =>
-                m.id === tempAssistantMsgId
+                m.id === tempAssistantMsgId && m.isStreaming
                   ? { ...m, statusText: event.message }
                   : m,
               ),
@@ -291,7 +291,7 @@ export const useChatMessages = () => {
 
           // ── FinalResponse LLM 시작 → 새 말풍선 생성 ────────────
           case "llm.message.started": {
-            if (FINAL_NODES.has(event.node)) {
+            if (FINAL_NODES.has(event.node) && !finalLLMMsgId) {
               finalLLMMsgId = event.message_id;
               const newId = `final-${Date.now()}`;
               finalRespMsgId = newId;

--- a/src/features/chat/hooks/useChatMessages.ts
+++ b/src/features/chat/hooks/useChatMessages.ts
@@ -258,107 +258,176 @@ export const useChatMessages = () => {
     };
   }, []);
 
-  /** SSE 스트림을 파싱하여 메시지 상태를 실시간 업데이트 */
+  /** SSE v2 스트림을 파싱하여 메시지 상태를 실시간 업데이트 */
   const processStream = useCallback(
     async (
       response: Response,
       tempAssistantMsgId: string,
       signal: AbortSignal,
     ) => {
+      // FinalResponse LLM의 message_id (이 ID의 토큰만 최종 말풍선에 표시)
+      let finalLLMMsgId: string | null = null;
+      // FinalResponse 전용 말풍선 ID (처음 토큰이 오면 동적 생성)
+      let finalRespMsgId: string | null = null;
+
+      // FinalResponse 또는 단순 응답 노드
+      const FINAL_NODES = new Set(["FinalResponse", "Simple_response", "Fallback"]);
+
       for await (const event of parseSSEStream(response)) {
         if (signal.aborted) return;
 
-        switch (event.type) {
-          case "thread_id":
-            // 스레드 ID 수신 — 필요 시 저장 가능
-            break;
-
-          case "message":
-            if (
-              event.content.type === "custom" &&
-              event.content.custom_data?.status
-            ) {
-              // 진행 상황 업데이트 (ThinkingBar에 표시)
-              setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === tempAssistantMsgId
-                    ? { ...m, statusText: event.content.custom_data.status }
-                    : m,
-                ),
-              );
-            } else if (event.content.type === "ai") {
-              // 최종 응답 — 서버 응답과 클라이언트 누적이 다를 경우에만 교체 (정합성 보장)
-              // 같으면 깜빡임 방지를 위해 유지 (statusText만 제거)
-              setMessages((prev) =>
-                prev.map((m) => {
-                  if (m.id !== tempAssistantMsgId) return m;
-
-                  // 내용이 다르면 교체, 같으면 유지
-                  if (m.content !== event.content.content) {
-                    return {
-                      ...m,
-                      content: event.content.content,
-                      statusText: undefined,
-                    };
-                  }
-
-                  // 내용이 같으면 statusText만 제거
-                  return { ...m, statusText: undefined };
-                }),
-              );
-            }
-            break;
-
-          case "token":
-            // LLM 토큰 실시간 누적 (사용자에게 보이는 텍스트)
+        switch (event.event) {
+          // ── 진행 상황 → ThinkingBar ──────────────────────────────
+          case "node.progress": {
             setMessages((prev) =>
               prev.map((m) =>
                 m.id === tempAssistantMsgId
-                  ? {
-                      ...m,
-                      content: m.content + event.content,
-                      statusText: undefined,
-                    }
+                  ? { ...m, statusText: event.message }
                   : m,
               ),
             );
             break;
+          }
 
-          case "DONE":
+          // ── FinalResponse LLM 시작 → 새 말풍선 생성 ────────────
+          case "llm.message.started": {
+            if (FINAL_NODES.has(event.node)) {
+              finalLLMMsgId = event.message_id;
+              const newId = `final-${Date.now()}`;
+              finalRespMsgId = newId;
+
+              setMessages((prev) => {
+                // 기존 생각 말풍선 닫기
+                const updated = prev.map((m) =>
+                  m.id === tempAssistantMsgId
+                    ? { ...m, isStreaming: false, statusText: undefined }
+                    : m,
+                );
+                // FinalResponse 전용 말풍선 추가
+                return [
+                  ...updated,
+                  {
+                    id: newId,
+                    role: "assistant" as const,
+                    content: "",
+                    isStreaming: true,
+                  },
+                ];
+              });
+            }
+            break;
+          }
+
+          // ── 실시간 토큰 → FinalResponse 말풍선에 누적 ──────────
+          case "llm.token.delta": {
+            if (
+              finalLLMMsgId &&
+              event.message_id === finalLLMMsgId &&
+              finalRespMsgId
+            ) {
+              const targetId = finalRespMsgId;
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === targetId
+                    ? { ...m, content: m.content + event.delta }
+                    : m,
+                ),
+              );
+            }
+            break;
+          }
+
+          // ── 완성된 메시지 확정 ───────────────────────────────────
+          case "chat.message": {
+            if (
+              event.kind === "assistant_final" ||
+              event.kind === "assistant_partial"
+            ) {
+              const content =
+                typeof event.content === "string"
+                  ? event.content
+                  : String(event.content ?? "");
+
+              // 토큰 스트리밍이 있었으면 finalRespMsgId, 없었으면 tempAssistantMsgId에 확정
+              const targetId = finalRespMsgId ?? tempAssistantMsgId;
+              setMessages((prev) =>
+                prev.map((m) => {
+                  if (m.id !== targetId) return m;
+                  if (m.content !== content) {
+                    return { ...m, content, statusText: undefined };
+                  }
+                  return { ...m, statusText: undefined };
+                }),
+              );
+
+              if (!finalRespMsgId) {
+                // 토큰 스트리밍 없이 chat.message만 온 경우
+                finalRespMsgId = tempAssistantMsgId;
+              }
+            } else if (event.kind === "system_notice") {
+              // 크레딧 부족 등 시스템 알림 → 별도 말풍선
+              const content =
+                typeof event.content === "string"
+                  ? event.content
+                  : "시스템 알림";
+              const noticeId = `notice-${Date.now()}`;
+              setMessages((prev) => [
+                ...prev,
+                {
+                  id: noticeId,
+                  role: "assistant" as const,
+                  content,
+                  isStreaming: false,
+                },
+              ]);
+            }
+            break;
+          }
+
+          // ── 스트리밍 완료 ────────────────────────────────────────
+          case "run.completed": {
             setMessages((prev) =>
               prev.map((m) =>
-                m.id === tempAssistantMsgId
+                m.isStreaming
                   ? { ...m, isStreaming: false, statusText: undefined }
                   : m,
               ),
             );
             break;
+          }
 
-          case "error":
-            console.error("[SSE] 서버 에러:", event.content);
+          // ── 스트리밍 실패 ────────────────────────────────────────
+          case "run.failed": {
+            console.error("[SSE v2] run.failed:", event.message);
             setMessages((prev) =>
               prev.map((m) =>
-                m.id === tempAssistantMsgId
+                m.isStreaming
                   ? {
                       ...m,
                       isStreaming: false,
                       statusText: undefined,
                       content:
-                        typeof event.content === "string"
-                          ? event.content
-                          : "응답 중 오류가 발생했어요.",
+                        m.content ||
+                        event.message ||
+                        "응답 중 오류가 발생했어요.",
                     }
                   : m,
               ),
             );
             return;
+          }
+
+          // heartbeat, session.metadata, node.started/completed,
+          // llm.message.completed, tool.call.*, credit.updated, artifact.ready
+          default:
+            break;
         }
       }
 
-      // DONE 이벤트 없이 스트림 종료된 경우 안전하게 처리
+      // 스트림이 run.completed 없이 종료된 경우 안전하게 처리
       setMessages((prev) =>
         prev.map((m) =>
-          m.id === tempAssistantMsgId && m.isStreaming
+          m.isStreaming
             ? { ...m, isStreaming: false, statusText: undefined }
             : m,
         ),

--- a/src/features/editor/api/editor_api.ts
+++ b/src/features/editor/api/editor_api.ts
@@ -118,15 +118,20 @@ export const uploadCanvasImage = async (
 };
 
 /**
- * SSE 스트림 파서
- * fetch Response에서 SSE 이벤트를 비동기 제너레이터로 파싱합니다.
+ * SSE v2 스트림 파서
+ * fetch Response에서 SSE v2 이벤트를 비동기 제너레이터로 파싱합니다.
  *
- * 지원 형식:
- * - data: {"type":"thread_id",...}  → JSON 파싱
- * - data: {"type":"message",...}    → JSON 파싱 (진행 상황 / 최종 응답)
- * - data: {"type":"token",...}      → JSON 파싱 (실시간 텍스트)
- * - data: {"type":"error",...}      → JSON 파싱
- * - data: [DONE]                     → 스트림 종료
+ * SSE v2 형식 (이벤트 블록은 빈 줄로 구분):
+ *   id: {run_id}:{seq}
+ *   event: {event_name}
+ *   data: {JSON payload}
+ *
+ * 주요 이벤트:
+ *   node.progress       → ThinkingBar 진행 상황 (data.message)
+ *   llm.token.delta     → LLM 실시간 토큰 (data.delta, data.node)
+ *   chat.message        → 완성된 메시지 (data.kind, data.content)
+ *   run.completed       → 스트리밍 완료
+ *   run.failed          → 스트리밍 오류
  */
 export const parseSSEStream = async function* (
   response: Response,
@@ -139,49 +144,51 @@ export const parseSSEStream = async function* (
   const decoder = new TextDecoder();
   let buffer = "";
 
+  function* parseBlock(block: string): Generator<SSEEvent> {
+    if (!block.trim()) return;
+
+    let eventType = "";
+    let dataStr = "";
+
+    for (const line of block.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("event:")) {
+        eventType = trimmed.slice(6).trim();
+      } else if (trimmed.startsWith("data:")) {
+        dataStr = trimmed.slice(5).trim();
+      }
+      // id: 와 주석(:)은 무시
+    }
+
+    if (!dataStr || !eventType) return;
+
+    try {
+      const data = JSON.parse(dataStr);
+      yield { event: eventType, ...data } as SSEEvent;
+    } catch {
+      // 파싱 불가 이벤트 무시
+    }
+  }
+
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || "";
 
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith(":")) continue;
+      // SSE 이벤트 블록은 빈 줄(\n\n)로 구분
+      const blocks = buffer.split("\n\n");
+      buffer = blocks.pop() ?? "";
 
-        if (trimmed.startsWith("data:")) {
-          const data = trimmed.slice(5).trim();
-          if (data === "[DONE]") {
-            yield { type: "DONE" };
-            return;
-          }
-          try {
-            yield JSON.parse(data) as SSEEvent;
-          } catch {
-            // JSON 파싱 실패 시 token 이벤트로 래핑
-            yield { type: "token", content: data } as SSEEvent;
-          }
-        }
+      for (const block of blocks) {
+        yield* parseBlock(block);
       }
     }
-    // 스트림 종료 후 잔여 버퍼 처리
-    buffer += decoder.decode(); // flush decoder
-    const remaining = buffer.trim();
-    if (remaining && remaining.startsWith("data:")) {
-      const data = remaining.slice(5).trim();
-      if (data === "[DONE]") {
-        yield { type: "DONE" };
-      } else {
-        try {
-          yield JSON.parse(data) as SSEEvent;
-        } catch {
-          yield { type: "token", content: data } as SSEEvent;
-        }
-      }
-    }
+
+    // 잔여 버퍼 flush
+    buffer += decoder.decode();
+    yield* parseBlock(buffer);
   } finally {
     reader.releaseLock();
   }

--- a/src/features/editor/types/editor_types.ts
+++ b/src/features/editor/types/editor_types.ts
@@ -279,64 +279,149 @@ export interface CanvasImageUploadResponse {
 }
 
 // ============================================================
-// SSE 스트리밍 이벤트 타입 (POST /api/conversations?isStream=true)
+// SSE 스트리밍 이벤트 타입 v2 (POST /api/conversations?isStream=true)
+// AI 서버 /stream/v2 프로토콜 — SSE event: 헤더로 이벤트 구분
 // ============================================================
 
-/** thread_id 이벤트 — 스트리밍 시작, 대화 스레드 ID 수신 */
-export interface SSEThreadIdEvent {
-  type: "thread_id";
-  thread_id: string;
+/** SSE v2 공통 envelope (모든 이벤트에 포함) */
+export interface SSEv2Envelope {
+  v: string;
+  ts: string;
+  seq: number;
   run_id: string;
+  thread_id: string;
 }
 
-/** 진행 상황용 custom_data */
-export interface SSECustomData {
+/** session.metadata — 스트리밍 세션 시작 */
+export interface SSEv2SessionMetadata extends SSEv2Envelope {
+  event: "session.metadata";
+  agent_id?: string;
+}
+
+/** run.started — 에이전트 실행 시작 */
+export interface SSEv2RunStarted extends SSEv2Envelope {
+  event: "run.started";
+  stream_tokens?: boolean;
+}
+
+/** node.started — 노드 실행 시작 */
+export interface SSEv2NodeStarted extends SSEv2Envelope {
+  event: "node.started";
+  node: string;
+  node_path?: string;
+}
+
+/** node.progress — 노드 진행 상황 (ThinkingBar에 표시) */
+export interface SSEv2NodeProgress extends SSEv2Envelope {
+  event: "node.progress";
+  node: string;
+  message: string;
+}
+
+/** node.completed — 노드 실행 완료 */
+export interface SSEv2NodeCompleted extends SSEv2Envelope {
+  event: "node.completed";
+  node: string;
+  status: string;
+  duration_ms: number;
+}
+
+/** llm.message.started — LLM 호출 시작 */
+export interface SSEv2LLMMessageStarted extends SSEv2Envelope {
+  event: "llm.message.started";
+  message_id: string;
+  node: string;
+  role: string;
+}
+
+/** llm.token.delta — LLM 실시간 토큰 스트리밍 */
+export interface SSEv2LLMTokenDelta extends SSEv2Envelope {
+  event: "llm.token.delta";
+  message_id: string;
+  node: string;
+  delta: string;
+  index: number;
+}
+
+/** llm.message.completed — LLM 호출 완료 */
+export interface SSEv2LLMMessageCompleted extends SSEv2Envelope {
+  event: "llm.message.completed";
+  message_id: string;
+  finish_reason: string;
+}
+
+/** chat.message — 완성된 메시지 (최종 응답 확정) */
+export interface SSEv2ChatMessage extends SSEv2Envelope {
+  event: "chat.message";
+  message_id: string;
+  role: string;
+  kind:
+    | "status"
+    | "assistant_partial"
+    | "assistant_final"
+    | "tool_result"
+    | "review"
+    | "suggestion"
+    | "system_notice";
+  content: unknown;
   node?: string;
-  status?: string;
-  final_output?: unknown;
 }
 
-/** SSE ChatMessage 구조 (message 이벤트의 content) */
-export interface SSEChatMessageContent {
-  type: "human" | "ai" | "tool" | "custom";
-  content: string;
-  tool_calls: unknown[];
-  tool_call_id: string | null;
-  run_id: string | null;
-  response_metadata: Record<string, unknown>;
-  custom_data: SSECustomData;
+/** artifact.ready — PDF 등 생성물 준비 완료 */
+export interface SSEv2ArtifactReady extends SSEv2Envelope {
+  event: "artifact.ready";
+  artifact_id: string;
+  name: string;
+  mime: string;
+  path: string;
+  size: number;
 }
 
-/** message 이벤트 — 진행 상황(custom) 또는 최종 응답(ai) */
-export interface SSEMessageEvent {
-  type: "message";
-  content: SSEChatMessageContent;
+/** credit.updated — 크레딧 잔액 업데이트 */
+export interface SSEv2CreditUpdated extends SSEv2Envelope {
+  event: "credit.updated";
+  balance: number;
+  total_cost: number;
+  remaining: number;
 }
 
-/** token 이벤트 — LLM 토큰 스트리밍 (실시간 텍스트 조각) */
-export interface SSETokenEvent {
-  type: "token";
-  content: string;
+/** heartbeat — 연결 유지 */
+export interface SSEv2Heartbeat extends SSEv2Envelope {
+  event: "heartbeat";
+  alive: boolean;
 }
 
-/** DONE 이벤트 — 스트림 종료 */
-export interface SSEDoneEvent {
-  type: "DONE";
+/** run.completed — 스트리밍 완료 */
+export interface SSEv2RunCompleted extends SSEv2Envelope {
+  event: "run.completed";
+  duration_ms: number;
+  final_message_id?: string;
 }
 
-/** error 이벤트 — 서버 에러 */
-export interface SSEErrorEvent {
-  type: "error";
-  content: string;
+/** run.failed — 스트리밍 실패 */
+export interface SSEv2RunFailed extends SSEv2Envelope {
+  event: "run.failed";
+  code: string;
+  message: string;
+  retryable: boolean;
 }
 
-/** SSE 이벤트 유니온 타입 */
+/** SSE v2 이벤트 유니온 타입 */
 export type SSEEvent =
-  | SSEThreadIdEvent
-  | SSEMessageEvent
-  | SSETokenEvent
-  | SSEDoneEvent
-  | SSEErrorEvent;
+  | SSEv2SessionMetadata
+  | SSEv2RunStarted
+  | SSEv2NodeStarted
+  | SSEv2NodeProgress
+  | SSEv2NodeCompleted
+  | SSEv2LLMMessageStarted
+  | SSEv2LLMTokenDelta
+  | SSEv2LLMMessageCompleted
+  | SSEv2ChatMessage
+  | SSEv2ArtifactReady
+  | SSEv2CreditUpdated
+  | SSEv2Heartbeat
+  | SSEv2RunCompleted
+  | SSEv2RunFailed;
 
 // ============================================================
 // API 응답 타입 별칭


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #243 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- Spring v2 스트리밍 이벤트 처리에 맞게 프론트 코드 수정
- SSE v2 이벤트 타입으로 교체 및 `parseSSEStream` 파싱 로직 수정
- `FinalResponse` 노드에 대한 별도의 말풍선 생성 처리

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스트리밍 v2에 맞춘 최종 응답 분리 표시로 최종 어시스턴트 메시지 안정화
  * 최종 로딩 상태용 애니메이티드 로딩 바 및 동적 상태 메시지 추가
  * 중간 진행 상태(heartbeat)로 실시간 진행률 노출 개선

* **Bug Fixes**
  * 스트리밍 메시지의 종료 및 오류 처리 일관성 개선
  * 중간/최종 메시지 교체와 상태 텍스트 동기화 문제 해결
<!-- end of auto-generated comment: release notes by coderabbit.ai -->