### PR TITLE
Docs(#252): 문서 간 충돌 해소 및 아키텍처 결정 사항 반영

### DIFF
--- a/docs/design.system.md
+++ b/docs/design.system.md
@@ -2,7 +2,7 @@
 
 | 카테고리      | 토큰 이름        | 색상 (Hex) | 설명 및 용도                         |
 | ------------- | ---------------- | ---------- | ------------------------------------ |
-| **Primary**   | `primary-main`   | `#2046FF`  | 브랜드 메인 컬러                     |
+| **Primary**   | `primary-main`   | `#2A6AFF`  | 브랜드 메인 컬러                     |
 |               | `primary-dark`   | `#1428A0`  | 메인 컬러 어두운 변형 (Hover/Active) |
 |               | `primary-darker` | `#002F6C`  | 메인 컬러 가장 어두운 변형           |
 | **Point**     | `point-light`    | `#2549C6`  | 밝은 포인트 컬러                     |
@@ -48,77 +48,120 @@ _(피그마에 명시된 토큰은 없으나 버튼/UI 등에서 보편적으로
   - `xl`: `16px`
   - `full`: `9999px` (원형 버튼, 뱃지)
 
+> **참고**: Tailwind v4 기본값(`md=6px`, `lg=8px`, `xl=12px`)과 다르므로 `@theme`에 명시적으로 재정의 필요.
+
 ---
 
-### 🛠️ 2. tailwind.config.ts 세팅 코드
+### 🛠️ 2. Tailwind v4 `@theme` 설정 코드
 
-추출한 디자인 시스템 명세서를 Tailwind CSS 환경에서 바로 사용할 수 있도록 `tailwind.config.ts` 형식으로 작성한 코드입니다. (Tailwind CSS v3 기준 작성되었으며, 프로젝트 구조에 맞게 `theme.extend` 영역에 병합하여 사용하시면 됩니다.)
+> ⚠️ **이 프로젝트는 Tailwind CSS v4를 사용합니다.**  
+> `tailwind.config.ts`에 `theme.extend`를 추가하는 **v3 방식은 동작하지 않습니다.**  
+> 모든 토큰은 `src/app/styles/global.css`의 `@theme` 블록에 CSS 변수로 정의해야 합니다.
 
-```tsx
-import type { Config } from "tailwindcss";
+```css
+/* src/app/styles/global.css — @theme 블록에 병합 */
+@theme {
+  /* ── 색상 (--color-* 네임스페이스) ─────────────────────────── */
+  /* bg-primary-main / text-primary-main / border-primary-main 클래스 생성 */
+  --color-primary-main: #2a6aff;
+  --color-primary-dark: #1428a0;
+  --color-primary-darker: #002f6c;
+  --color-point-light: #2549c6;
+  --color-point-main: #122d8b;
 
-const config: Config = {
-  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  theme: {
-    extend: {
-      fontFamily: {
-        sans: ["Pretendard", "sans-serif"],
-      },
-      colors: {
-        primary: {
-          main: "#2046FF",
-          dark: "#1428A0",
-          darker: "#002F6C",
-        },
-        point: {
-          light: "#2549C6",
-          main: "#122D8B",
-        },
-        gray: {
-          50: "#F1F4F8",
-          100: "#E3E7ED",
-          200: "#D1D6DE",
-          400: "#9CA4B0",
-          600: "#6B7280",
-          800: "#2F3440",
-        },
-        text: {
-          main: "#414141",
-          body: "#4D4D4D",
-          white: "#FFFFFF",
-        },
-        wireframe: "#D0D0D0",
-        semantic: {
-          success: "#0AA63E",
-          warning: "#E2A242",
-          error: "#DC3545",
-        },
-      },
-      fontSize: {
-        "display-1": ["64px", { lineHeight: "74px", fontWeight: "700" }],
-        "display-2": ["48px", { lineHeight: "58px", fontWeight: "700" }],
-        h1: ["36px", { lineHeight: "46px", fontWeight: "700" }],
-        "h2-semibold": ["32px", { lineHeight: "42px", fontWeight: "600" }],
-        "h2-medium": ["32px", { lineHeight: "42px", fontWeight: "500" }],
-        h3: ["28px", { lineHeight: "40px", fontWeight: "600" }],
-        h4: ["24px", { lineHeight: "32px", fontWeight: "700" }],
-        "body-1-bold": ["20px", { lineHeight: "24px", fontWeight: "700" }],
-        "body-1-semibold": ["20px", { lineHeight: "24px", fontWeight: "600" }],
-        "body-2-medium": ["20px", { lineHeight: "24px", fontWeight: "500" }],
-        "body-2-regular": ["20px", { lineHeight: "24px", fontWeight: "400" }],
-      },
-      borderRadius: {
-        sm: "4px",
-        md: "8px",
-        lg: "12px",
-        xl: "16px",
-      },
-    },
-  },
-  plugins: [],
-};
+  --color-gray-50: #f1f4f8;
+  --color-gray-100: #e3e7ed;
+  --color-gray-200: #d1d6de;
+  --color-gray-400: #9ca4b0;
+  --color-gray-600: #6b7280;
+  --color-gray-800: #2f3440;
 
-export default config;
+  --color-text-main: #414141;
+  --color-text-body: #4d4d4d;
+  --color-text-white: #ffffff;
+  --color-wireframe: #d0d0d0;
+
+  --color-semantic-success: #0aa63e;
+  --color-semantic-warning: #e2a242;
+  --color-semantic-error: #dc3545;
+
+  /* ── 폰트 사이즈 (--text-* 네임스페이스) ──────────────────── */
+  /* ⚠️ --font-size-* 아님. v4 공식 네임스페이스는 --text-* */
+  /* line-height / font-weight는 이중 대시(--)로 연결 */
+  --text-display-1: 64px;
+  --text-display-1--line-height: 74px;
+  --text-display-1--font-weight: 700;
+
+  --text-display-2: 48px;
+  --text-display-2--line-height: 58px;
+  --text-display-2--font-weight: 700;
+
+  --text-h1: 36px;
+  --text-h1--line-height: 46px;
+  --text-h1--font-weight: 700;
+
+  --text-h2-semibold: 32px;
+  --text-h2-semibold--line-height: 42px;
+  --text-h2-semibold--font-weight: 600;
+
+  --text-h2-medium: 32px;
+  --text-h2-medium--line-height: 42px;
+  --text-h2-medium--font-weight: 500;
+
+  --text-h3: 28px;
+  --text-h3--line-height: 40px;
+  --text-h3--font-weight: 600;
+
+  --text-h4: 24px;
+  --text-h4--line-height: 32px;
+  --text-h4--font-weight: 700;
+
+  --text-body-1-bold: 20px;
+  --text-body-1-bold--line-height: 24px;
+  --text-body-1-bold--font-weight: 700;
+
+  --text-body-1-semibold: 20px;
+  --text-body-1-semibold--line-height: 24px;
+  --text-body-1-semibold--font-weight: 600;
+
+  --text-body-2-medium: 20px;
+  --text-body-2-medium--line-height: 24px;
+  --text-body-2-medium--font-weight: 500;
+
+  --text-body-2-regular: 20px;
+  --text-body-2-regular--line-height: 24px;
+  --text-body-2-regular--font-weight: 400;
+
+  /* ── Border Radius (--radius-* 네임스페이스) ──────────────── */
+  /* ⚠️ Tailwind v4 기본값(md=6px, lg=8px, xl=12px)을 덮어씁니다 */
+  --radius-sm: 4px;
+  --radius-md: 8px; /* 기본 6px → 덮어씀 */
+  --radius-lg: 12px; /* 기본 8px → 덮어씀 */
+  --radius-xl: 16px; /* 기본 12px → 덮어씀 */
+  --radius-full: 9999px;
+
+  /* ── 브레이크포인트 (--breakpoint-* 네임스페이스) ─────────── */
+  /* Option B: 팀 컨벤션 외 prefix를 initial로 비활성화 */
+  --breakpoint-sm: initial; /* 기본 640px 제거 — sm: prefix 사용 금지 */
+  --breakpoint-xl: initial; /* 기본 1280px 제거 — xl: prefix 사용 금지 */
+  --breakpoint-2xl: initial; /* 기본 1536px 제거 — 2xl: prefix 사용 금지 */
+
+  --breakpoint-md: 48rem; /* 768px — Tablet */
+  --breakpoint-lg: 64rem; /* 1024px — Desktop */
+  --breakpoint-3xl: 85rem; /* 1360px — Wide */
+}
 ```
 
-> 향후 UI 코드 리팩토링 시 `text-display-1`, `bg-primary-main`, `text-text-main` 등의 클래스로 즉시 맵핑하여 사용할 수 있는 환경 설정용 기준 데이터입니다.
+**클래스 사용 예시**
+
+| CSS 변수                 | 생성되는 Tailwind 클래스                                        |
+| ------------------------ | --------------------------------------------------------------- |
+| `--color-primary-main`   | `bg-primary-main` / `text-primary-main` / `border-primary-main` |
+| `--color-semantic-error` | `bg-semantic-error` / `text-semantic-error`                     |
+| `--text-h1`              | `text-h1` (size + line-height + font-weight 동시 적용)          |
+| `--radius-lg`            | `rounded-lg`                                                    |
+| `--radius-full`          | `rounded-full`                                                  |
+
+**`--color-text-*` 네이밍 주의**  
+`--color-text-main`으로 등록하면 클래스가 `text-text-main`이 됩니다(`text-` prefix 중복).  
+기능상 동작하지만 어색합니다. 팀이 원한다면 `--color-foreground: #414141` 형태로 변경해 `text-foreground`로 쓸 수 있습니다. **현재는 `text-text-main` 형태를 유지합니다.**

--- a/docs/new_refactor.md
+++ b/docs/new_refactor.md
@@ -70,7 +70,7 @@ src/app/styles/global.css의 @theme 블록에 CSS 변수로 정의
 현재 `global.css`의 `@theme` 블록에는 폰트(`--font-sans`)와 브레이크포인트(`--breakpoint-3xl`) 만 정의되어 있고, 색상·폰트 사이즈·border-radius 등 디자인 토큰이 전혀 없습니다.
 
 **왜 문제인가?**  
-디자인 토큰이 전역으로 등록되어 있지 않으면, 모든 컴포넌트에서 색상값을 하드코딩하거나(`#2046FF`, `#F1F4F8` 등) 파일별로 정의한 상수(`toolbar_styles.ts`)에 의존해야 합니다. 이는 색상 하나를 바꿀 때 수십 개의 파일을 수동으로 찾아 고쳐야 하는 구조를 만듭니다.
+디자인 토큰이 전역으로 등록되어 있지 않으면, 모든 컴포넌트에서 색상값을 하드코딩하거나(`#2A6AFF`, `#F1F4F8` 등) 파일별로 정의한 상수(`toolbar_styles.ts`)에 의존해야 합니다. 이는 색상 하나를 바꿀 때 수십 개의 파일을 수동으로 찾아 고쳐야 하는 구조를 만듭니다.
 
 ---
 
@@ -192,7 +192,7 @@ src/
 /* 이렇게 추가해야 합니다 (v4 방식, 공식 문서 기준) */
 @theme {
   /* 색상 — --color-* 네임스페이스 */
-  --color-primary-main: #2046ff;
+  --color-primary-main: #2a6aff; /* ✅ 확정: 기존 코드 기준값 */
   --color-primary-dark: #1428a0;
   --color-primary-darker: #002f6c;
   --color-point-light: #2549c6;
@@ -264,6 +264,7 @@ src/
   --radius-md: 8px; /* Tailwind 기본 6px — 덮어씀 */
   --radius-lg: 12px; /* Tailwind 기본 8px — 덮어씀 */
   --radius-xl: 16px; /* Tailwind 기본 12px — 덮어씀 */
+  --radius-full: 9999px;
 }
 ```
 
@@ -306,44 +307,37 @@ Tailwind v4 공식 문서는 기본 브레이크포인트가 rem 기반이므로
 **⚠️ "강제"가 아닌 "팀 컨벤션 명시"**:  
 `@theme`에 `--breakpoint-md`와 `--breakpoint-lg`를 추가해도 Tailwind 기본값인 `sm:`, `xl:`, `2xl:` prefix는 자동으로 사라지지 않습니다. 기본 브레이크포인트를 완전히 제거하려면 `initial` 키워드로 명시적으로 비활성화해야 합니다.
 
-**해야 할 작업**:  
-아래 세 가지 선택지 중 팀이 결정합니다.
-
-**[선택지 A] 팀 컨벤션만 명시 (느슨한 강제)**  
-기본 브레이크포인트는 유지하되 `@theme`에 우리 기준값을 명시해 코드 리뷰 기준으로 사용합니다.  
-`sm:`, `xl:` 등 기본 prefix가 여전히 동작하므로 컨벤션 위반 방지 효과는 낮습니다.
-
-```css
-@theme {
-  --breakpoint-md: 48rem; /* 768px */
-  --breakpoint-lg: 64rem; /* 1024px */
-  --breakpoint-3xl: 85rem; /* 1360px, 기존 1360px → rem 변환 */
-}
-```
-
-**[선택지 B] 불필요한 기본 브레이크포인트 제거 (강한 강제)**  
-우리가 쓰지 않기로 한 `sm:`, `xl:`, `2xl:` prefix를 `initial`로 비활성화합니다.  
+**적용 방향 — Option B 확정**:  
+불필요한 `sm:`, `xl:`, `2xl:` prefix를 `initial`로 비활성화합니다.  
 코드에서 `xl:` 같은 클래스를 쓰면 아무 효과가 없으므로 컨벤션 위반이 즉시 드러납니다.
 
+> ⚠️ **사전 작업 필수**: `initial` 적용 전 기존 코드에서 `sm:`, `xl:`, `2xl:` 사용 현황을 전수 조사하고 `md:` 또는 `lg:`로 교체해야 합니다.
+>
+> ```bash
+> rg "sm:|xl:|2xl:" src/ -l
+> ```
+
 ```css
 @theme {
-  --breakpoint-sm: initial; /* 기본 sm(640px) 제거 */
-  --breakpoint-xl: initial; /* 기본 xl(1280px) 제거 */
-  --breakpoint-2xl: initial; /* 기본 2xl(1536px) 제거 */
+  /* ① 제거 — initial 선언은 새 값 정의보다 먼저 위치해야 함 */
+  --breakpoint-sm: initial; /* 기본 640px 제거 — sm: prefix 사용 금지 */
+  --breakpoint-xl: initial; /* 기본 1280px 제거 — xl: prefix 사용 금지 */
+  --breakpoint-2xl: initial; /* 기본 1536px 제거 — 2xl: prefix 사용 금지 */
 
+  /* ② 팀 컨벤션 브레이크포인트 (rem 단위 통일) */
   --breakpoint-md: 48rem; /* 768px — Tablet */
   --breakpoint-lg: 64rem; /* 1024px — Desktop */
   --breakpoint-3xl: 85rem; /* 1360px — Wide */
 }
 ```
 
-**권장: 선택지 B.** 허용하지 않는 prefix를 명시적으로 제거해야 팀 컨벤션이 실제로 강제됩니다. 단, 기존 코드에서 `sm:`, `xl:` 클래스를 이미 사용 중인 곳이 있다면 교체 작업이 필요합니다.
-
 ```
-팀 컨벤션 기준 (결정 후 이 문서에 반영):
-Mobile  (기본, 0px ~ 767px):    별도 prefix 없음, 모바일 퍼스트
+✅ 확정된 팀 컨벤션:
 Tablet  (md:, 768px ~ 1023px):  md: prefix
 Desktop (lg:, 1024px ~):        lg: prefix
+Wide    (3xl:, 1360px ~):       3xl: prefix (특수 케이스에만 사용)
+
+금지: sm:, xl:, 2xl: prefix (initial로 비활성화됨)
 ```
 
 ---
@@ -710,27 +704,37 @@ Phase 1~4를 거치면서 교체되지 않은 인라인 스타일과 하드코�
 
 ## 9. 반응형 디자인 표준화 가이드
 
-모든 컴포넌트는 **모바일 퍼스트(Mobile-First)** 원칙으로 작성합니다.
+### 지원 환경 및 전략
+
+> **이 프로젝트는 태블릿(768px~)과 데스크탑(1024px~) 환경만 지원합니다. 모바일(~767px)은 지원 대상이 아닙니다.**
+
+CSS 작성 방식은 **최소 너비(min-width) 기반 상향 확장** 방식을 따릅니다. prefix 없는 기본 클래스는 태블릿 미만 환경을 포함하지만, **모바일 화면에서의 레이아웃 완성도는 보장하지 않습니다.**
 
 ```
-기본 클래스 (Mobile, 0px~767px):
-  → 최소 폭 375px 기준 작성
-  → 예시: w-full px-4 text-base
+기본 클래스 (태블릿 미만 포함, 768px 미만):
+  → 태블릿 레이아웃의 기반값으로 작성
+  → 예시: w-full px-6 text-base
 
 md: prefix (Tablet, 768px~1023px):
-  → 태블릿 세로 모드 대응, 2단 그리드 전환
+  → 태블릿 환경 레이아웃 분기점, 2단 그리드 전환 등
   → 예시: md:px-8 md:grid-cols-2
 
 lg: prefix (Desktop, 1024px~):
   → PC 환경, 최대 너비 제한 + 중앙 정렬
   → 예시: lg:max-w-[1200px] mx-auto
+
+3xl: prefix (Wide, 1360px~):
+  → 와이드 모니터 대응이 필요한 특수 케이스에만 사용
+  → 팀 논의 후 적용
 ```
 
 **금지 사항**:
 
-- `sm:` prefix 사용 지양 (모바일 퍼스트에서 불필요)
-- `xl:`, `2xl:` prefix는 특수 케이스에만 사용하고 팀 논의 후 적용
+- `sm:`, `xl:`, `2xl:` prefix 사용 금지 (`@theme`에서 `initial`로 비활성화됨)
 - 반응형 없는 고정 px 너비 (`w-[500px]` 등) 사용 금지
+
+**참고 — "모바일 퍼스트"와의 차이**:  
+"모바일 퍼스트(Mobile-First)"는 CSS 방법론 용어로, 기본값을 가장 좁은 화면에 맞추고 `min-width`로 확장하는 방식입니다. 이 프로젝트는 이 방법론을 CSS 작성 패턴으로 따르되, 실제 **모바일 화면 지원은 비즈니스 요구사항이 아닙니다**. 두 개념을 혼동하지 않도록 합니다.
 
 ---
 

--- a/docs/phases/phase_1.md
+++ b/docs/phases/phase_1.md
@@ -40,7 +40,7 @@
 ```css
 @theme {
   /* ── 색상 (--color-* 네임스페이스) ─────────────────────────── */
-  --color-primary-main: #2046ff;
+  --color-primary-main: #2a6aff; /* ✅ 확정: 기존 코드 기준값 */
   --color-primary-dark: #1428a0;
   --color-primary-darker: #002f6c;
   --color-point-light: #2549c6;
@@ -117,6 +117,7 @@
   --radius-md: 8px;
   --radius-lg: 12px;
   --radius-xl: 16px;
+  --radius-full: 9999px;
 }
 ```
 
@@ -139,29 +140,21 @@
 | 현행 유지   | `text-text-main`  | 디자인 시스템 네이밍 그대로             |
 | 시맨틱 변경 | `text-foreground` | `--color-foreground: #414141` 으로 변경 |
 
-### ⚠️ 팀 결정 필요 — `#2046FF` vs `#2A6AFF` 색상 충돌
+### ✅ 색상 확정 — `primary-main: #2A6AFF`
 
-디자인 시스템(`design_system.md`)의 `primary-main`은 `#2046FF`이지만,  
-실제 코드에는 `#2A6AFF`가 광범위하게 사용되고 있다.
+기존 코드베이스 전반에서 `#2A6AFF`가 사용되고 있었으므로 이 값으로 확정한다.  
+`design_system.md`의 원래 값(`#2046FF`)은 이 문서 업데이트와 함께 `#2A6AFF`로 일괄 수정 완료.
 
 ```
-확인된 사용 파일:
+✅ 확정: --color-primary-main: #2a6aff
+확인된 교체 대상 파일 (토큰 적용 시 기존 하드코딩 제거):
   - src/features/auth/pages/LoginPage.tsx
   - src/features/auth/pages/SignupPage.tsx (focus:border-[#2A6AFF] 다수)
   - src/features/editor/constants/toolbar_styles.ts (active 색상)
   - 기타 다수
 ```
 
-토큰 등록 전 아래 두 방향 중 하나를 팀이 결정해야 한다.  
-**결정 없이 `#2046FF`로 토큰을 등록하면 UI 전체 색감이 바뀐다.**
-
-| 방향                       | 내용                                                                  | 영향                                      |
-| -------------------------- | --------------------------------------------------------------------- | ----------------------------------------- |
-| A. 디자인 시스템 기준 적용 | `--color-primary-main: #2046ff` 등록 후 기존 `#2A6AFF` 전량 교체      | UI 색상 변경됨 — 디자이너 확인 필요       |
-| B. 기존 코드 색상 반영     | `--color-primary-main: #2A6AFF`로 토큰 등록                           | 디자인 시스템과 불일치 — 피그마 수정 필요 |
-| C. 별도 토큰 추가          | `--color-primary-main: #2046ff` + `--color-interactive: #2A6AFF` 분리 | 토큰 체계 복잡해짐                        |
-
-**이 결정이 내려지기 전까지 1-A 작업을 시작하지 않는다.**
+토큰 등록 후 위 파일들의 `#2A6AFF` 하드코딩을 `primary-main` 토큰 클래스로 교체한다.
 
 ### ⚠️ 완료 후 해야 할 것
 
@@ -187,64 +180,45 @@
 Tailwind v4는 기본 브레이크포인트가 `rem` 기반이므로 **단위 혼재 시 미디어쿼리 순서가 어긋날 수 있다**.  
 또한 팀 컨벤션 3단계(Mobile/Tablet/Desktop)가 코드에 강제되지 않아 컴포넌트마다 기준이 다를 수 있다.
 
-### 팀 결정 필요 — 선택지 A vs B
+### ✅ 확정 — Option B (불필요한 prefix 제거)
 
-**[선택지 A] 컨벤션만 명시 (느슨)**  
-기본 `sm:`, `xl:`, `2xl:` prefix가 살아있어 컨벤션 위반을 막기 어렵다.
+`sm:`, `xl:`, `2xl:`을 `initial`로 비활성화해 컨벤션 위반을 코드 레벨에서 차단한다.
 
-```css
-@theme {
-  --breakpoint-md: 48rem; /* 768px  — Tablet */
-  --breakpoint-lg: 64rem; /* 1024px — Desktop */
-  --breakpoint-3xl: 85rem; /* 1360px — Wide (기존 1360px → rem 변환) */
-}
-```
-
-**[선택지 B] 불필요한 prefix 제거 (강한 강제) — 권장**  
-`sm:`, `xl:`, `2xl:`을 `initial`로 비활성화해 실수를 코드 레벨에서 차단한다.  
-단, 기존 코드에서 `sm:`, `xl:`, `2xl:`, `3xl:`을 사용하는 곳을 먼저 파악하고 교체해야 한다.
+> ⚠️ **사전 작업 필수 (1-B 시작 전)**: 기존 코드의 `sm:`, `xl:`, `2xl:` 사용 현황을 전수 조사하고 `md:` 또는 `lg:`로 교체해야 한다.
+>
+> ```bash
+> rg "sm:|xl:|2xl:" src/ -l
+> ```
 
 ```css
 @theme {
-  --breakpoint-sm: initial; /* 640px  제거 */
-  --breakpoint-xl: initial; /* 1280px 제거 */
-  --breakpoint-2xl: initial; /* 1536px 제거 */
+  /* ① 제거 — initial 선언은 새 값 정의보다 먼저 위치 */
+  --breakpoint-sm: initial; /* 640px  제거 — sm: prefix 사용 금지 */
+  --breakpoint-xl: initial; /* 1280px 제거 — xl: prefix 사용 금지 */
+  --breakpoint-2xl: initial; /* 1536px 제거 — 2xl: prefix 사용 금지 */
 
+  /* ② 팀 컨벤션 브레이크포인트 (rem 단위 통일) */
   --breakpoint-md: 48rem; /* 768px  — Tablet */
   --breakpoint-lg: 64rem; /* 1024px — Desktop */
   --breakpoint-3xl: 85rem; /* 1360px — Wide */
 }
 ```
 
-### 선택지 B 진행 시 사전 작업
-
-아래 명령으로 기존 코드의 `sm:`, `xl:`, `2xl:`, `3xl:` 사용 현황을 파악한다.
-
-```bash
-# sm: 사용 파일 목록
-rg "sm:" src/ -l
-
-# xl:, 2xl:, 3xl: 사용 파일 목록
-rg "xl:|2xl:|3xl:" src/ -l
-```
-
-파악된 파일들에서 `md:` 또는 `lg:`로 대체하거나 팀 논의 후 처리한다.
-
-### 팀 컨벤션 기준 (결정 후 모든 신규 코드에 적용)
+### ✅ 확정된 팀 컨벤션
 
 ```
-Mobile  (기본, 0~767px):     prefix 없음  — 모바일 퍼스트 기본값
-Tablet  (md:, 768~1023px):  md: prefix
-Desktop (lg:, 1024px~):     lg: prefix
-```
+Tablet  (md:, 768px~1023px):  md: prefix
+Desktop (lg:, 1024px~):       lg: prefix
+Wide    (3xl:, 1360px~):      3xl: prefix (특수 케이스에만 사용)
 
-**금지**: `sm:`, `xl:`, `2xl:` (팀 컨벤션 외 prefix) / 고정 px 너비 (`w-[500px]`)
+금지: sm:, xl:, 2xl: prefix / 고정 px 너비 (w-[500px])
+```
 
 ### 완료 기준
 
-- `--breakpoint-3xl: 1360px` → `85rem` 으로 수정 완료
-- 선택지 A/B 팀 결정 후 `@theme` 반영 완료
-- 선택지 B 선택 시 기존 `sm:`/`xl:` 사용 코드 전량 교체 완료
+- `--breakpoint-3xl: 1360px` → `85rem` 수정 완료
+- `sm:`, `xl:`, `2xl:` initial 비활성화 반영 완료
+- 기존 `sm:`/`xl:`/`2xl:` 사용 코드 전량 `md:` 또는 `lg:`로 교체 완료
 
 ---
 

--- a/docs/phases/phase_4.md
+++ b/docs/phases/phase_4.md
@@ -573,9 +573,12 @@ Phase 2의 Button, Input 컴포넌트 완료 필요.
 
 ## 완료 기준 (Phase 4 전체)
 
+> ⚠️ `NavigationEventBridge.tsx`는 **Phase 1-D**에서 생성·등록하는 파일이다.  
+> Phase 4 시작 전에 이미 존재해야 한다. Phase 4에서 다시 생성하지 않는다.
+
+- [ ] **전제 확인**: `src/shared/router/NavigationEventBridge.tsx` 파일 존재 (Phase 1-D 산출물)
 - [ ] `src/shared/auth/token_storage.ts` 파일 존재
 - [ ] `src/shared/auth/AuthEventBridge.tsx` 파일 존재 + `main.tsx` 렌더 트리에 등록됨
-- [ ] `src/shared/router/NavigationEventBridge.tsx` 파일 존재 + router 최상단에 등록됨 (Phase 1-D)
 - [ ] 로그아웃 후 `localStorage`에 `accessToken`, `refreshToken` 잔존하지 않음
 - [ ] 새로고침 후 로그인 세션 유지 정상 동작
 - [ ] 401 자동 갱신 → `proovy:token-refreshed` 이벤트 발생 → `setToken()` 호출 → 재시도 플로우 정상 동작


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #252 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- primary-main 색상을 #2A6AFF로 확정 (기존 코드 기준)
- 브레이크포인트 Option B 확정 (sm/xl/2xl initial 비활성화)
- 모든 브레이크포인트 단위를 px → rem으로 통일
- design.system.md: Tailwind v3 config 코드를 v4 @theme 블록으로 전면 교체, radius full 추가
- new_refactor.md: 9절 반응형 가이드를 "태블릿/데스크탑 전용" 전략으로 명확화
- phase_1.md: 색상/브레이크포인트 팀 결정 사항 반영, 결정 전 블로킹 문구 제거
- phase_4.md: NavigationEventBridge 완료 기준 귀속 오류 수정 (Phase 1-D 산출물임을 명시)

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 디자인 시스템 문서 업데이트: 색상 토큰 표준화 및 Tailwind 마이그레이션 안내 추가
  * 제품 로드맵 상세화: 반응형 디자인 표준, 인증 시스템 개선, 네비게이션 기능 강화 계획 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->