### PR TITLE
[Refactor] Phase 1-D: client.ts 라우팅 우회 제거 및 NavigationEventBridge 도입

### DIFF
--- a/src/app/router/routes.tsx
+++ b/src/app/router/routes.tsx
@@ -21,6 +21,7 @@ import {
   ProtectedRoute,
   PublicRoute,
 } from "../../shared/router/components/RouteGuards";
+import { RootRoute } from "../../shared/router/RootRoute";
 
 // Features - Chat
 import { ChatPage } from "../../features/chat/pages/ChatPage";
@@ -35,98 +36,103 @@ import { StoragePage } from "../../features/storage/pages/StoragePage";
 import { PricingPage } from "../../features/subscription/pages/PricingPage";
 
 export const router = createBrowserRouter([
-  // ========================================
-  // 🌐 Public Routes (인증 지향적이나 로그인이 필수는 아님)
-  // ========================================
   {
-    path: "/",
-    element: <PublicRoute />,
+    element: <RootRoute />,
     children: [
+      // ========================================
+      // 🌐 Public Routes (인증 지향적이나 로그인이 필수는 아님)
+      // ========================================
       {
-        index: true,
-        element: <LandingPage />,
-      },
-      {
-        path: "login",
-        element: <LoginPage />,
-      },
-      {
-        path: "signup",
-        element: <SignupPage />,
-      },
-    ],
-  },
-  {
-    path: "/oauth/kakao/callback",
-    element: <KakaoCallbackPage />,
-  },
-  {
-    path: "/oauth/naver/callback",
-    element: <NaverCallbackPage />,
-  },
-  {
-    path: "/oauth/google/callback",
-    element: <GoogleCallbackPage />,
-  },
-
-  // ========================================
-  // 🔒 Protected Routes (인증 필요)
-  // ========================================
-  {
-    path: "/app",
-    element: <ProtectedRoute />,
-    children: [
-      {
-        element: <AppLayout />,
+        path: "/",
+        element: <PublicRoute />,
         children: [
-          // 홈 - 새 노트 시작점
           {
-            path: "home",
-            element: <HomePage />,
+            index: true,
+            element: <LandingPage />,
           },
-          // 노트 목록 - 전체 노트 리스트
           {
-            path: "notes",
-            element: <NotesPage />,
+            path: "login",
+            element: <LoginPage />,
           },
-          // 저장소 - 전체 파일 리스트
           {
-            path: "storage",
-            element: <StoragePage />,
-          },
-          // 대화방
-          {
-            path: "chat/:noteId",
-            element: <ChatPage />,
+            path: "signup",
+            element: <SignupPage />,
           },
         ],
       },
-    ],
-  },
+      {
+        path: "/oauth/kakao/callback",
+        element: <KakaoCallbackPage />,
+      },
+      {
+        path: "/oauth/naver/callback",
+        element: <NaverCallbackPage />,
+      },
+      {
+        path: "/oauth/google/callback",
+        element: <GoogleCallbackPage />,
+      },
 
-  // 요금제 페이지 (Sidebar 없음)
-  {
-    path: "/pricing",
-    element: <PricingPage />,
-  },
-  {
-    path: "/error/401",
-    element: <UnauthorizedPage />,
-  },
-  {
-    path: "/error/403",
-    element: <ForbiddenPage />,
-  },
-  {
-    path: "/error/404",
-    element: <NotFoundPage />,
-  },
-  {
-    path: "/error/500",
-    element: <ServerErrorPage />,
-  },
-  {
-    path: "*",
-    element: <NotFoundPage />,
+      // ========================================
+      // 🔒 Protected Routes (인증 필요)
+      // ========================================
+      {
+        path: "/app",
+        element: <ProtectedRoute />,
+        children: [
+          {
+            element: <AppLayout />,
+            children: [
+              // 홈 - 새 노트 시작점
+              {
+                path: "home",
+                element: <HomePage />,
+              },
+              // 노트 목록 - 전체 노트 리스트
+              {
+                path: "notes",
+                element: <NotesPage />,
+              },
+              // 저장소 - 전체 파일 리스트
+              {
+                path: "storage",
+                element: <StoragePage />,
+              },
+              // 대화방
+              {
+                path: "chat/:noteId",
+                element: <ChatPage />,
+              },
+            ],
+          },
+        ],
+      },
+
+      // 요금제 페이지 (Sidebar 없음)
+      {
+        path: "/pricing",
+        element: <PricingPage />,
+      },
+      {
+        path: "/error/401",
+        element: <UnauthorizedPage />,
+      },
+      {
+        path: "/error/403",
+        element: <ForbiddenPage />,
+      },
+      {
+        path: "/error/404",
+        element: <NotFoundPage />,
+      },
+      {
+        path: "/error/500",
+        element: <ServerErrorPage />,
+      },
+      {
+        path: "*",
+        element: <NotFoundPage />,
+      },
+    ],
   },
 ]);

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -38,8 +38,9 @@ const redirectToErrorRoute = (route: string) => {
   const currentPath = window.location.pathname;
   if (currentPath === route || currentPath.startsWith("/error/")) return;
 
-  window.history.replaceState(window.history.state, "", route);
-  window.dispatchEvent(new PopStateEvent("popstate"));
+  window.dispatchEvent(
+    new CustomEvent("proovy:navigate", { detail: { route } }),
+  );
 };
 
 const resolveErrorRoute = (error: AxiosError) => {

--- a/src/shared/router/NavigationEventBridge.tsx
+++ b/src/shared/router/NavigationEventBridge.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+type NavigationEventDetail = {
+  route: string;
+};
+
+export function NavigationEventBridge() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleNavigate = (event: CustomEvent<NavigationEventDetail>) => {
+      navigate(event.detail.route, { replace: true });
+    };
+
+    window.addEventListener("proovy:navigate", handleNavigate as EventListener);
+
+    return () => {
+      window.removeEventListener(
+        "proovy:navigate",
+        handleNavigate as EventListener,
+      );
+    };
+  }, [navigate]);
+
+  return null;
+}

--- a/src/shared/router/RootRoute.tsx
+++ b/src/shared/router/RootRoute.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+import { NavigationEventBridge } from "./NavigationEventBridge";
+
+export function RootRoute() {
+  return (
+    <>
+      <NavigationEventBridge />
+      <Outlet />
+    </>
+  );
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #255

## 🏷️ PR 타입

- [x] ♻️ 리팩토링 (Refactoring)

## 📝 작업 내용

- `client.ts`의 `window.history.replaceState` + `PopStateEvent` 직접 조작 제거
- `redirectToErrorRoute`를 `CustomEvent(proovy:navigate)` 발행 방식으로 교체
- `NavigationEventBridge.tsx` 신규 생성 — `useNavigate` 기반으로 React Router 정상 경유
- `RootRoute.tsx` 신규 생성 — 라우터 최상단에 `NavigationEventBridge` 전역 마운트 (공개 라우트 포함 전 경로에서 수신 가능)

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 셀프 리뷰를 완료했습니다
- [x] 코드 스타일 가이드를 준수했습니다

## 📎 기타 참고사항

- `tokenUtils`는 Phase 4 토큰 단일화 작업에서 처리 예정으로 이번 PR 범위 외
- `AppLayout`은 `/app/*` 보호 라우트에서만 마운트되므로 전역 이벤트 수신 위치로 부적합 → `RootRoute` 채택

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 리팩토링

* 라우팅 및 네비게이션 시스템의 내부 아키텍처를 개선하였습니다.

---

*이번 업데이트는 시스템 안정성을 향상시키기 위한 내부 개선 사항입니다. 사용자가 인지할 수 있는 기능 변화는 없습니다.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->