### PR TITLE
Feat(#254): 반응형 공통 레이아웃 시스템 구축(PageContainer / ContentGrid)

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -3,7 +3,9 @@
 @import "tailwindcss";
 
 @theme {
-  --breakpoint-3xl: 1360px;
+  --breakpoint-sm: initial; /* 640px 제거 — 모바일 미지원 */
+  --breakpoint-2xl: initial; /* 1536px 제거 — 3xl로 통합 */
+  --breakpoint-3xl: 1360px; /* 와이드 데스크탑 */
 
   /* 2. 테일윈드의 기본 'sans' 폰트 변수를 Pretendard로 덮어쓰기 */
   /* 이렇게 하면 별도로 font-pretendard를 선언하지 않아도 모든 기본 텍스트에 적용된다. */

--- a/src/features/notes/components/NotesGrid.tsx
+++ b/src/features/notes/components/NotesGrid.tsx
@@ -2,6 +2,7 @@ import { NotesAddCard } from "./NotesAddCard";
 import { NoteCard } from "./NoteCard";
 import { LoadingSpinner } from "../../../shared/components/loading-spinner";
 import type { NoteDto } from "../api/notes_types";
+import { ContentGrid } from "@/shared/layout/ContentGrid";
 
 interface NotesGridProps {
   notes: NoteDto[];
@@ -26,41 +27,39 @@ export const NotesGrid = ({
   const placeholderCount = Math.max(0, totalSlots - usedSlots);
 
   return (
-    <div className="mt-[21px] flex justify-center">
-      <div className="3xl:grid-cols-5 grid w-full grid-cols-2 gap-[20px] lg:grid-cols-3 2xl:grid-cols-4">
-        {showAddCard && <NotesAddCard />}
+    <ContentGrid className="mt-[21px]">
+      {showAddCard && <NotesAddCard />}
 
-        {isLoading ? (
-          <div className="col-span-full flex items-center justify-center py-[40px]">
-            <LoadingSpinner size={80} />
-          </div>
-        ) : notes.length > 0 ? (
-          <>
-            {notes.map((note) => (
-              <NoteCard
-                key={note.noteId}
-                note={note}
-                isSelectMode={isSelectMode}
-                isSelected={selectedIds.includes(note.noteId)}
-                onToggleSelection={onToggleSelection}
-              />
-            ))}
-            {Array.from({ length: placeholderCount }).map((_, index) => (
-              <div
-                key={`placeholder-${index}`}
-                aria-hidden="true"
-                className="h-[204px] w-full rounded-[12px] border-[0.5px] border-transparent bg-transparent"
-              />
-            ))}
-          </>
-        ) : (
-          <div className="col-span-full flex items-center justify-center py-[40px]">
-            <span className="text-[14px] leading-[20px] text-[#6D6D6D]">
-              노트가 없습니다.
-            </span>
-          </div>
-        )}
-      </div>
-    </div>
+      {isLoading ? (
+        <div className="col-span-full flex items-center justify-center py-[40px]">
+          <LoadingSpinner size={80} />
+        </div>
+      ) : notes.length > 0 ? (
+        <>
+          {notes.map((note) => (
+            <NoteCard
+              key={note.noteId}
+              note={note}
+              isSelectMode={isSelectMode}
+              isSelected={selectedIds.includes(note.noteId)}
+              onToggleSelection={onToggleSelection}
+            />
+          ))}
+          {Array.from({ length: placeholderCount }).map((_, index) => (
+            <div
+              key={`placeholder-${index}`}
+              aria-hidden="true"
+              className="h-[204px] w-full rounded-[12px] border-[0.5px] border-transparent bg-transparent"
+            />
+          ))}
+        </>
+      ) : (
+        <div className="col-span-full flex items-center justify-center py-[40px]">
+          <span className="text-[14px] leading-[20px] text-[#6D6D6D]">
+            노트가 없습니다.
+          </span>
+        </div>
+      )}
+    </ContentGrid>
   );
 };

--- a/src/features/notes/components/NotesHeader.tsx
+++ b/src/features/notes/components/NotesHeader.tsx
@@ -54,105 +54,95 @@ export const NotesHeader = ({
   }, [isSortDropdownOpen, onToggleSortDropdown]);
 
   return (
-    <div className="w-full">
-      <div className="mb-[23px] flex justify-center">
-        <div className="3xl:max-w-[1360px] w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
-          <h1 className="font-['Pretendard'] text-[40px] leading-[52px] font-semibold text-black">
-            노트 목록
-          </h1>
-        </div>
-      </div>
+    <>
+      <h1 className="mb-[23px] font-['Pretendard'] text-[40px] leading-[52px] font-semibold text-black">
+        노트 목록
+      </h1>
 
-      <div className="flex justify-center">
-        <div className="3xl:max-w-[1360px] w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-[8px]">
-              <div
-                className="relative"
-                ref={dropdownRef}
-              >
-                <button
-                  ref={toggleRef}
-                  type="button"
-                  onClick={() => onToggleSortDropdown(!isSortDropdownOpen)}
-                  className="flex w-[140px] cursor-pointer items-center justify-between overflow-hidden rounded-[8px] border-[0.5px] border-[#D1D6DE] bg-white px-[12px] py-[10px] transition-colors hover:bg-gray-50"
-                >
-                  <span className="font-['Noto_Sans_KR',sans-serif] text-[14px] leading-[15px] font-normal whitespace-nowrap text-[#2F3440]">
-                    {SORT_OPTIONS.find((option) => option.value === sortOrder)
-                      ?.label ?? "정렬"}
-                  </span>
-                  <span className="h-[16px] w-[16px] shrink-0">
-                    <DropdownIcon
-                      className={`h-full w-full text-[#2F3440] transition-transform ${
-                        isSortDropdownOpen ? "rotate-180" : ""
-                      }`}
-                    />
-                  </span>
-                </button>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-[8px]">
+          <div
+            className="relative"
+            ref={dropdownRef}
+          >
+            <button
+              ref={toggleRef}
+              type="button"
+              onClick={() => onToggleSortDropdown(!isSortDropdownOpen)}
+              className="flex w-[140px] cursor-pointer items-center justify-between overflow-hidden rounded-[8px] border-[0.5px] border-[#D1D6DE] bg-white px-[12px] py-[10px] transition-colors hover:bg-gray-50"
+            >
+              <span className="font-['Noto_Sans_KR',sans-serif] text-[14px] leading-[15px] font-normal whitespace-nowrap text-[#2F3440]">
+                {SORT_OPTIONS.find((option) => option.value === sortOrder)
+                  ?.label ?? "정렬"}
+              </span>
+              <span className="h-[16px] w-[16px] shrink-0">
+                <DropdownIcon
+                  className={`h-full w-full text-[#2F3440] transition-transform ${
+                    isSortDropdownOpen ? "rotate-180" : ""
+                  }`}
+                />
+              </span>
+            </button>
 
-                {isSortDropdownOpen && (
-                  <div className="absolute right-0 z-10 mt-[4px] w-[192px] rounded-[8px] border border-[#D1D6DE] bg-white py-[4px] shadow-[0_8px_20px_rgba(0,0,0,0.08)]">
-                    {SORT_OPTIONS.map((option) => (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() => onSelectSort(option.value)}
-                        className={`mx-[4px] flex w-[calc(100%-8px)] cursor-pointer items-center rounded-[8px] px-[12px] py-[8px] text-left text-[13px] leading-[18px] transition-shadow ${
-                          sortOrder === option.value
-                            ? "border border-[#2A6AFF] font-medium text-[#003880]"
-                            : "text-[#2F3440] hover:shadow-[0_0_0_3px_rgba(42,106,255,0.15)]"
-                        }`}
-                      >
-                        {option.label}
-                      </button>
-                    ))}
-                  </div>
-                )}
+            {isSortDropdownOpen && (
+              <div className="absolute right-0 z-10 mt-[4px] w-[192px] rounded-[8px] border border-[#D1D6DE] bg-white py-[4px] shadow-[0_8px_20px_rgba(0,0,0,0.08)]">
+                {SORT_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => onSelectSort(option.value)}
+                    className={`mx-[4px] flex w-[calc(100%-8px)] cursor-pointer items-center rounded-[8px] px-[12px] py-[8px] text-left text-[13px] leading-[18px] transition-shadow ${
+                      sortOrder === option.value
+                        ? "border border-[#2A6AFF] font-medium text-[#003880]"
+                        : "text-[#2F3440] hover:shadow-[0_0_0_3px_rgba(42,106,255,0.15)]"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
               </div>
-
-              {isSelectMode ? (
-                <div className="flex items-center gap-[8px]">
-                  <button
-                    onClick={onCancelSelectMode}
-                    className="flex h-[32px] w-[80px] cursor-pointer items-center justify-center rounded-xl border-[0.5px] border-[#D1D6DE] bg-white font-['Pretendard'] text-[14px] font-medium text-[#9CA4B0] transition-colors duration-200 hover:border-transparent hover:bg-[#2A6AFF]/50 hover:text-white active:border-transparent active:bg-[#2A6AFF] active:text-white"
-                    type="button"
-                  >
-                    취소
-                  </button>
-                  <button
-                    onClick={onDeleteClick}
-                    disabled={selectedCount === 0}
-                    className="flex h-[32px] w-[80px] cursor-pointer items-center justify-center rounded-xl border-[0.5px] border-[#D1D6DE] bg-white font-['Pretendard'] text-[14px] font-medium text-[#2A6AFF] transition-colors duration-200 hover:border-transparent hover:bg-[#2A6AFF]/50 hover:text-white active:border-transparent active:bg-[#2A6AFF] active:text-white disabled:cursor-not-allowed disabled:opacity-50"
-                    type="button"
-                  >
-                    삭제하기
-                  </button>
-                </div>
-              ) : (
-                <button
-                  onClick={onEnterSelectMode}
-                  className="flex h-[32px] w-[80px] cursor-pointer items-center justify-center rounded-xl border-[0.5px] border-[#D1D6DE] bg-white font-['Pretendard'] text-[14px] font-medium text-[#9CA4B0] transition-colors duration-200 hover:border-transparent hover:bg-[#2A6AFF]/50 hover:text-white active:border-transparent active:bg-[#2A6AFF] active:text-white"
-                  type="button"
-                >
-                  선택
-                </button>
-              )}
-            </div>
-
-            <div className="flex items-center gap-[8px]">
-              <span className="text-[16px] leading-[20px] font-medium text-black">
-                노트 개수
-              </span>
-              <span className="text-[16px] leading-[20px] font-medium">
-                <span className="font-bold text-[#2A6AFF]">
-                  {totalElements}
-                </span>
-                <span className="text-black">/{maxNotes ?? totalElements}</span>
-              </span>
-            </div>
+            )}
           </div>
+
+          {isSelectMode ? (
+            <div className="flex items-center gap-[8px]">
+              <button
+                onClick={onCancelSelectMode}
+                className="flex h-[32px] w-[80px] cursor-pointer items-center justify-center rounded-xl border-[0.5px] border-[#D1D6DE] bg-white font-['Pretendard'] text-[14px] font-medium text-[#9CA4B0] transition-colors duration-200 hover:border-transparent hover:bg-[#2A6AFF]/50 hover:text-white active:border-transparent active:bg-[#2A6AFF] active:text-white"
+                type="button"
+              >
+                취소
+              </button>
+              <button
+                onClick={onDeleteClick}
+                disabled={selectedCount === 0}
+                className="flex h-[32px] w-[80px] cursor-pointer items-center justify-center rounded-xl border-[0.5px] border-[#D1D6DE] bg-white font-['Pretendard'] text-[14px] font-medium text-[#2A6AFF] transition-colors duration-200 hover:border-transparent hover:bg-[#2A6AFF]/50 hover:text-white active:border-transparent active:bg-[#2A6AFF] active:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                type="button"
+              >
+                삭제하기
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={onEnterSelectMode}
+              className="flex h-[32px] w-[80px] cursor-pointer items-center justify-center rounded-xl border-[0.5px] border-[#D1D6DE] bg-white font-['Pretendard'] text-[14px] font-medium text-[#9CA4B0] transition-colors duration-200 hover:border-transparent hover:bg-[#2A6AFF]/50 hover:text-white active:border-transparent active:bg-[#2A6AFF] active:text-white"
+              type="button"
+            >
+              선택
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-[8px]">
+          <span className="text-[16px] leading-[20px] font-medium text-black">
+            노트 개수
+          </span>
+          <span className="text-[16px] leading-[20px] font-medium">
+            <span className="font-bold text-[#2A6AFF]">{totalElements}</span>
+            <span className="text-black">/{maxNotes ?? totalElements}</span>
+          </span>
         </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/features/notes/pages/NotesPage.tsx
+++ b/src/features/notes/pages/NotesPage.tsx
@@ -8,6 +8,7 @@ import {
   DeleteNotesModal,
   DeletionSuccessModal,
 } from "../components";
+import { PageContainer } from "@/shared/layout/PageContainer";
 
 export const NotesPage = () => {
   const { data: profile } = useMyProfile();
@@ -56,44 +57,38 @@ export const NotesPage = () => {
   }
 
   return (
-    <div className="flex h-screen w-full flex-col overflow-y-auto bg-white pt-[97px] pb-20">
-      <div className="mx-auto w-full max-w-[1680px]">
-        <NotesHeader
-          sortOrder={sortOrder}
-          isSortDropdownOpen={isSortDropdownOpen}
-          isSelectMode={isSelectMode}
-          totalElements={displayTotalElements}
-          maxNotes={maxNotes}
-          selectedCount={selectedIds.length}
-          onSelectSort={handleSelectSort}
-          onToggleSortDropdown={setIsSortDropdownOpen}
-          onEnterSelectMode={handleEnterSelectMode}
-          onCancelSelectMode={handleCancelSelectMode}
-          onDeleteClick={handleDeleteClick}
-        />
+    <PageContainer>
+      <NotesHeader
+        sortOrder={sortOrder}
+        isSortDropdownOpen={isSortDropdownOpen}
+        isSelectMode={isSelectMode}
+        totalElements={displayTotalElements}
+        maxNotes={maxNotes}
+        selectedCount={selectedIds.length}
+        onSelectSort={handleSelectSort}
+        onToggleSortDropdown={setIsSortDropdownOpen}
+        onEnterSelectMode={handleEnterSelectMode}
+        onCancelSelectMode={handleCancelSelectMode}
+        onDeleteClick={handleDeleteClick}
+      />
 
-        <div className="flex justify-center">
-          <div className="3xl:max-w-[1360px] w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
-            <NotesGrid
-              notes={notes}
-              isLoading={isLoading}
-              isSelectMode={isSelectMode}
-              selectedIds={selectedIds}
-              onToggleSelection={toggleIdSelection}
-              showAddCard={currentPage === 0}
-              totalSlots={6}
-            />
+      <NotesGrid
+        notes={notes}
+        isLoading={isLoading}
+        isSelectMode={isSelectMode}
+        selectedIds={selectedIds}
+        onToggleSelection={toggleIdSelection}
+        showAddCard={currentPage === 0}
+        totalSlots={6}
+      />
 
-            <NotesPagination
-              pageInfo={pageInfo}
-              currentPage={currentPage}
-              onPreviousPage={handlePreviousPage}
-              onNextPage={handleNextPage}
-              onPageChange={setCurrentPage}
-            />
-          </div>
-        </div>
-      </div>
+      <NotesPagination
+        pageInfo={pageInfo}
+        currentPage={currentPage}
+        onPreviousPage={handlePreviousPage}
+        onNextPage={handleNextPage}
+        onPageChange={setCurrentPage}
+      />
 
       {isDeleteModalOpen && (
         <DeleteNotesModal
@@ -105,6 +100,6 @@ export const NotesPage = () => {
       {isSuccessModalOpen && (
         <DeletionSuccessModal onClose={handleCloseSuccessModal} />
       )}
-    </div>
+    </PageContainer>
   );
 };

--- a/src/features/storage/components/NoteGroup.tsx
+++ b/src/features/storage/components/NoteGroup.tsx
@@ -99,6 +99,7 @@ export const NoteGroup = ({
           <ContentGrid
             className="mt-[20px]"
             gapClass="gap-[20px]"
+            cols={{ base: 2, xl: 3, xl3: 4 }}
           >
             {notes.map((asset) => (
               <NoteCard

--- a/src/features/storage/components/NoteGroup.tsx
+++ b/src/features/storage/components/NoteGroup.tsx
@@ -7,6 +7,7 @@ import {
   mapAssetCategory,
   mapOcrStatus,
 } from "../utils/asset-mapper";
+import { ContentGrid } from "@/shared/layout/ContentGrid";
 
 interface NoteGroupProps {
   title: string;
@@ -30,7 +31,7 @@ export const NoteGroup = ({
   const { isSelectMode, selectedIds, toggleIdSelection } = useStorageStore();
 
   return (
-    <div className="3xl:max-w-[1360px] mx-auto flex w-full max-w-[520px] flex-col lg:max-w-[800px] 2xl:max-w-[1080px]">
+    <div className="flex w-full flex-col">
       <button
         onClick={onToggle}
         className="mx-auto flex w-full cursor-pointer items-center justify-between rounded-[12px] border border-[#D1D6DE] bg-[#F1F4F8] px-[20px] py-[8px] transition-colors"
@@ -95,7 +96,10 @@ export const NoteGroup = ({
 
       {isOpen &&
         (notes.length > 0 ? (
-          <div className="3xl:grid-cols-5 mx-auto mt-[20px] grid w-full grid-cols-2 justify-center gap-x-[40px] gap-y-[20px] lg:grid-cols-3 2xl:grid-cols-4">
+          <ContentGrid
+            className="mt-[20px]"
+            gapClass="gap-[20px]"
+          >
             {notes.map((asset) => (
               <NoteCard
                 key={asset.assetId}
@@ -111,7 +115,7 @@ export const NoteGroup = ({
                 onSelect={() => toggleIdSelection(asset.assetId)}
               />
             ))}
-          </div>
+          </ContentGrid>
         ) : (
           <div className="mx-auto mt-[12px] flex h-[60px] w-full items-center justify-center rounded-[12px] border border-[#E0E0E0] bg-white">
             <span className="font-['Pretendard'] text-[13px] font-medium text-[#AEAEAE]">

--- a/src/features/storage/components/StorageToolbar.tsx
+++ b/src/features/storage/components/StorageToolbar.tsx
@@ -35,7 +35,7 @@ export const StorageToolbar = ({
   };
 
   return (
-    <div className="3xl:max-w-[1360px] mx-auto mb-[8px] grid w-full max-w-[520px] [grid-template-columns:1fr_auto] items-center gap-x-[32px] lg:max-w-[800px] 2xl:max-w-[1080px]">
+    <div className="mb-[8px] grid w-full [grid-template-columns:1fr_auto] items-center gap-x-[32px]">
       <div className="flex items-center gap-[20px]">
         <div
           className="relative w-[220px] lg:w-[440px]"

--- a/src/features/storage/pages/StoragePage.tsx
+++ b/src/features/storage/pages/StoragePage.tsx
@@ -17,6 +17,7 @@ import { DeleteNotesModal } from "../components/DeleteNotesModal";
 import { DeletionSuccessModal } from "../components/DeletionSuccessModal";
 import { useStorageInfo } from "../hooks/useAssets";
 import { EmptyState } from "@/shared/components/EmptyState";
+import { PageContainer } from "@/shared/layout/PageContainer";
 
 const getNearCapacityMessage = (planType?: string) => {
   const normalized = (planType ?? "").toLowerCase();
@@ -56,68 +57,55 @@ export const StoragePage = () => {
 
   return (
     <>
-      <div className="flex h-screen w-full flex-col overflow-y-auto bg-white pt-[97px] pb-20">
-        <div className="mx-auto w-full max-w-[1680px]">
-          {/* Header Section */}
-          <div className="mb-[23px] flex justify-center">
-            <div className="3xl:max-w-[1360px] w-full max-w-[520px] lg:max-w-[800px] 2xl:max-w-[1080px]">
-              <h1 className="font-['Pretendard'] text-[40px] leading-[52px] font-semibold text-black">
-                저장소
-              </h1>
-            </div>
-          </div>
+      <PageContainer>
+        <h1 className="mb-[23px] font-['Pretendard'] text-[40px] leading-[52px] font-semibold text-black">
+          저장소
+        </h1>
 
-          {/* Toolbar Row */}
-          <div className="flex justify-center">
-            <StorageToolbar
-              usagePercent={data?.usagePercent ?? 0}
-              totalUsedDisplay={data?.totalUsedDisplay ?? "0MB"}
-              totalLimitDisplay={data?.totalLimitDisplay ?? "0MB"}
-              onSearch={handleSearch}
-            />
-          </div>
+        <StorageToolbar
+          usagePercent={data?.usagePercent ?? 0}
+          totalUsedDisplay={data?.totalUsedDisplay ?? "0MB"}
+          totalLimitDisplay={data?.totalLimitDisplay ?? "0MB"}
+          onSearch={handleSearch}
+        />
 
-          {/* Note Groups Section */}
-          <div className="mt-[24px] flex flex-col items-center justify-center gap-[20px]">
-            {isLoading ? (
-              <p>데이터를 불러오는 중입니다...</p>
-            ) : error ? (
-              <p className="text-red-500">
-                데이터를 불러오는 중 오류가 발생했습니다.
-              </p>
-            ) : data?.notes && data.notes.length > 0 ? (
-              data.notes.map((note) => (
-                <NoteGroup
-                  key={note.noteId}
-                  title={note.title}
-                  storageUsedDisplay={note.storageUsedDisplay}
-                  storageLimitDisplay={note.storageLimitDisplay}
-                  usagePercent={Math.min(
-                    (note.storageUsed / note.storageLimit) * 100,
-                    100,
-                  )}
-                  notes={note.assets}
-                  isOpen={openNoteIds.includes(note.noteId)}
-                  onToggle={() => handleToggle(note.noteId)}
-                />
-              ))
-            ) : (
-              <EmptyState
-                message="업로드된 파일이 없습니다"
-                description="새로운 파일을 업로드하여 저장소를 채워보세요."
+        <div className="mt-[24px] flex flex-col gap-[20px]">
+          {isLoading ? (
+            <p>데이터를 불러오는 중입니다...</p>
+          ) : error ? (
+            <p className="text-red-500">
+              데이터를 불러오는 중 오류가 발생했습니다.
+            </p>
+          ) : data?.notes && data.notes.length > 0 ? (
+            data.notes.map((note) => (
+              <NoteGroup
+                key={note.noteId}
+                title={note.title}
+                storageUsedDisplay={note.storageUsedDisplay}
+                storageLimitDisplay={note.storageLimitDisplay}
+                usagePercent={Math.min(
+                  (note.storageUsed / note.storageLimit) * 100,
+                  100,
+                )}
+                notes={note.assets}
+                isOpen={openNoteIds.includes(note.noteId)}
+                onToggle={() => handleToggle(note.noteId)}
               />
-            )}
-          </div>
-
-          {showNearCapacityWarning && (
-            <div className="mt-6 flex justify-center">
-              <p className="font-['Pretendard'] text-[14px] font-medium text-[#FF3B30]">
-                {nearCapacityMessage}
-              </p>
-            </div>
+            ))
+          ) : (
+            <EmptyState
+              message="업로드된 파일이 없습니다"
+              description="새로운 파일을 업로드하여 저장소를 채워보세요."
+            />
           )}
         </div>
-      </div>
+
+        {showNearCapacityWarning && (
+          <p className="mt-6 font-['Pretendard'] text-[14px] font-medium text-[#FF3B30]">
+            {nearCapacityMessage}
+          </p>
+        )}
+      </PageContainer>
       {isDeleteModalOpen && <DeleteNotesModal />}
       {isSuccessModalOpen && <DeletionSuccessModal />}
     </>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -36,11 +36,11 @@ export const HomePage = () => {
     <div className="w-full bg-white">
       {/* 메인 홈 화면 - 한 화면을 꽉 채우는 구성 */}
       <div className="flex min-h-screen w-full flex-col items-center">
-        <div className="flex w-full flex-1 flex-col justify-center px-5 pt-[100px]">
+        <div className="flex w-full flex-1 flex-col justify-center px-5 pt-[97px]">
           <div className="mx-auto flex w-full max-w-[920px] flex-col items-center lg:items-start">
             {/* 타이틀 */}
             <div className="mb-8 w-full text-center lg:text-left">
-              <h1 className="text-[32px] leading-[42px] font-semibold tracking-[-0.008px] text-black sm:text-[40px] sm:leading-[52px]">
+              <h1 className="text-[40px] leading-[52px] font-semibold tracking-[-0.008px] text-black">
                 파일을 업로드하고 완벽한 해설을,
               </h1>
             </div>

--- a/src/shared/layout/ContentGrid.tsx
+++ b/src/shared/layout/ContentGrid.tsx
@@ -10,6 +10,14 @@ const BASE_COLS: Record<GridCols, string> = {
   5: "grid-cols-5",
 };
 
+const XL_COLS: Record<GridCols, string> = {
+  1: "xl:grid-cols-1",
+  2: "xl:grid-cols-2",
+  3: "xl:grid-cols-3",
+  4: "xl:grid-cols-4",
+  5: "xl:grid-cols-5",
+};
+
 const XL3_COLS: Record<GridCols, string> = {
   1: "3xl:grid-cols-1",
   2: "3xl:grid-cols-2",
@@ -23,6 +31,7 @@ interface ContentGridProps {
   className?: string;
   cols?: {
     base?: GridCols; /** 기본 컬럼 수 (default: 3) */
+    xl?: GridCols; /** xl(1280px+) 컬럼 수 */
     xl3?: GridCols; /** 3xl(1360px+) 컬럼 수 (default: 4) */
   };
   /** Tailwind gap 클래스 문자열 (default: "gap-[20px]") */
@@ -35,8 +44,15 @@ export const ContentGrid = ({
   cols = {},
   gapClass = "gap-[20px]",
 }: ContentGridProps) => {
-  const { base = 3, xl3 = 4 } = cols;
-  const classes = ["grid", BASE_COLS[base], gapClass, XL3_COLS[xl3], className]
+  const { base = 3, xl, xl3 = 4 } = cols;
+  const classes = [
+    "grid",
+    BASE_COLS[base],
+    gapClass,
+    xl != null ? XL_COLS[xl] : null,
+    XL3_COLS[xl3],
+    className,
+  ]
     .filter(Boolean)
     .join(" ");
 

--- a/src/shared/layout/ContentGrid.tsx
+++ b/src/shared/layout/ContentGrid.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+type GridCols = 1 | 2 | 3 | 4 | 5;
+
+const BASE_COLS: Record<GridCols, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-2",
+  3: "grid-cols-3",
+  4: "grid-cols-4",
+  5: "grid-cols-5",
+};
+
+const XL3_COLS: Record<GridCols, string> = {
+  1: "3xl:grid-cols-1",
+  2: "3xl:grid-cols-2",
+  3: "3xl:grid-cols-3",
+  4: "3xl:grid-cols-4",
+  5: "3xl:grid-cols-5",
+};
+
+interface ContentGridProps {
+  children: ReactNode;
+  className?: string;
+  cols?: {
+    base?: GridCols; /** 기본 컬럼 수 (default: 3) */
+    xl3?: GridCols; /** 3xl(1360px+) 컬럼 수 (default: 4) */
+  };
+  /** Tailwind gap 클래스 문자열 (default: "gap-[20px]") */
+  gapClass?: string;
+}
+
+export const ContentGrid = ({
+  children,
+  className,
+  cols = {},
+  gapClass = "gap-[20px]",
+}: ContentGridProps) => {
+  const { base = 3, xl3 = 4 } = cols;
+  const classes = ["grid", BASE_COLS[base], gapClass, XL3_COLS[xl3], className]
+    .filter(Boolean)
+    .join(" ");
+
+  return <div className={classes}>{children}</div>;
+};

--- a/src/shared/layout/PageContainer.tsx
+++ b/src/shared/layout/PageContainer.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+interface PageContainerProps {
+  children: ReactNode;
+  /** 최외곽 스크롤 div에 추가할 클래스 (padding 등 기본값 재정의 가능) */
+  className?: string;
+  /** 콘텐츠 너비 제한 div에 추가할 클래스 */
+  innerClassName?: string;
+}
+
+/**
+ * 앱 페이지 공통 래퍼.
+ * - 세로 스크롤 컨텍스트 (h-screen, overflow-y-auto)
+ * - 상단 97px / 하단 80px 기본 여백
+ * - 외곽 캡 max-w-[1680px]
+ * - 콘텐츠 너비: base → max-w-[800px] / 3xl(1360px+) → max-w-[1080px]
+ */
+export const PageContainer = ({
+  children,
+  className,
+  innerClassName,
+}: PageContainerProps) => (
+  <div
+    className={`h-screen w-full overflow-y-auto bg-white pt-[60px] pb-12${className ? ` ${className}` : ""}`}
+  >
+    <div className="mx-auto w-full max-w-[1680px]">
+      <div className="flex justify-center">
+        <div
+          className={`w-full max-w-[800px] 3xl:max-w-[1080px]${innerClassName ? ` ${innerClassName}` : ""}`}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  </div>
+);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #254

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

## Summary

- `PageContainer`, `ContentGrid` 공통 컴포넌트를 신규 생성해 전 페이지 레이아웃을 표준화
- Tailwind `sm:`, `2xl:` 브레이크포인트 비활성화로 cascade 역전 버그 해소
- 콘텐츠 너비 2단계(800px → 1080px), 그리드 컬럼 단계(2→3→4col) 반응형 기준 통일
- 저장소 페이지 카드 겹침 버그 수정 (NoteCard 240px 고정폭 대응)

## Changes

### New Files
- `src/shared/layout/PageContainer.tsx` — 페이지 공통 스크롤/패딩/너비 래퍼
- `src/shared/layout/ContentGrid.tsx` — 반응형 그리드 공통 컴포넌트 (base/xl/xl3 컬럼 지원)

### Modified Files
- `global.css` — `sm:`, `2xl:` 브레이크포인트 비활성화, `3xl: 1360px` 정의
- `NotesPage.tsx`, `StoragePage.tsx` — `PageContainer` 교체
- `NotesGrid.tsx`, `NoteGroup.tsx` — `ContentGrid` 교체
- `NotesHeader.tsx`, `StorageToolbar.tsx` — 중복 centering/max-w 클래스 제거
- `HomePage.tsx` — `sm:` 잔재 클래스 제거 및 padding 정렬

## Breakpoint Strategy

| 브레이크포인트 | 뷰포트 | 콘텐츠 너비 | Notes 그리드 | Storage 그리드 |
|---|---|---|---|---|
| base (md+) | 768px~ | 800px | 3col | 2col |
| xl | 1280px~ | 800px | 3col | 3col |
| 3xl | 1360px~ | 1080px | 4col | 4col |

## Test Plan
- [ ] 노트 목록 페이지: 1024 / 1280 / 1360px+ 뷰포트 확인
- [ ] 저장소 페이지: 카드 겹침 없음 (특히 1024~1279px 구간)
- [ ] 홈페이지: 레이아웃 깨짐 없음
- [ ] 정렬 드롭다운, 선택/삭제 모드 정상 동작 확인


## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 반응형 중단점(breakpoint) 설정 업데이트
  * 전체 앱의 레이아웃 일관성 개선
  * 노트 목록, 저장소 페이지의 UI 구조 개선
  * 홈페이지의 타이포그래피 및 간격 조정

* **리팩토링**
  * 공유 레이아웃 컴포넌트 도입으로 코드 재사용성 향상
  * 각 페이지의 마크업 구조 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->