### PR TITLE
Fix(#276): Viewer 패널 UI 개선

### DIFF
--- a/src/features/chat/components/divider/Divider.tsx
+++ b/src/features/chat/components/divider/Divider.tsx
@@ -15,17 +15,21 @@ export const Divider = ({
   isDragging,
 }: DividerProps) => {
   return (
-    <div className="relative z-10 flex w-0 items-center justify-center">
-      {/* 드래그 핸들 버튼 - 경계선 중심에 떠있는 형태 */}
+    <div className="relative z-10 flex h-full w-0 items-center justify-center">
+      {/* 세로 경계선 전체를 드래그 hit area로 사용 */}
       <div
         onMouseDown={onMouseDown}
         onTouchStart={onTouchStart}
-        className={`absolute flex h-[56px] w-[24px] cursor-col-resize touch-none flex-col items-center justify-center gap-[3px] rounded-[20px] border-[0.5px] border-[#D1D6DE] bg-white shadow-[4px_4px_15px_0px_rgba(0,0,0,0.1)] transition-all hover:scale-105 ${
-          isDragging ? "scale-105" : ""
-        }`}
+        className="group absolute inset-y-0 left-1/2 flex w-[24px] -translate-x-1/2 cursor-col-resize touch-none items-center justify-center"
       >
-        <ArrowLeftIcon size={14} />
-        <ArrowRightIcon size={14} />
+        <div
+          className={`flex h-[56px] w-[24px] flex-col items-center justify-center gap-[3px] rounded-[20px] border-[0.5px] border-[#D1D6DE] bg-white shadow-[4px_4px_15px_0px_rgba(0,0,0,0.1)] transition-all group-hover:scale-105 ${
+            isDragging ? "scale-105" : ""
+          }`}
+        >
+          <ArrowLeftIcon size={14} />
+          <ArrowRightIcon size={14} />
+        </div>
       </div>
     </div>
   );

--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -205,11 +205,11 @@ export const FileRenderer = ({
         </div>
 
         {/* 캔버스 영역 */}
-        <div className="flex min-h-0 flex-1 items-start justify-center overflow-auto bg-gray-50 p-4 pt-6">
-          <div className="shadow-lg">
+        <div className="flex min-h-0 flex-1 justify-center overflow-y-auto bg-gray-50 p-4 pt-6">
+          <div className="h-fit shadow-lg">
             <canvas
               ref={canvasRef}
-              className="block bg-white"
+              className="block h-auto max-w-full bg-white"
               draggable={false}
             />
           </div>

--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -24,22 +24,51 @@ export const FileRenderer = ({
   const [error, setError] = useState<string | null>(null);
 
   const [zoom, setZoom] = useState(1.0);
+  const zoomRef = useRef(1.0);
+  const zoomWrapperRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const lastTouchDistRef = useRef<number | null>(null);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const renderTaskRef = useRef<RenderTask | null>(null);
   const pdfRef = useRef<PDFDocumentProxy | null>(null);
+  const resizeRafRef = useRef<number | null>(null);
 
-  // 컨테이너 너비 감지 → 캔버스 base scale 계산에 사용
+  const contentWidth = Math.max(containerWidth - 32, 1);
+
+  // 컨테이너 너비 감지 → 다음 프레임에 반영해 드래그 중에도 즉시 크기 동기화
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
+
+    const updateWidth = (width: number) => {
+      if (resizeRafRef.current !== null) {
+        cancelAnimationFrame(resizeRafRef.current);
+      }
+
+      resizeRafRef.current = requestAnimationFrame(() => {
+        resizeRafRef.current = null;
+        setContainerWidth((prev) => (prev === width ? prev : width));
+      });
+    };
+
+    updateWidth(el.getBoundingClientRect().width);
+
     const ro = new ResizeObserver((entries) => {
-      setContainerWidth(entries[0].contentRect.width);
+      const entry = entries[0];
+      if (!entry) return;
+      updateWidth(entry.contentRect.width);
     });
+
     ro.observe(el);
-    return () => ro.disconnect();
+
+    return () => {
+      ro.disconnect();
+      if (resizeRafRef.current !== null) {
+        cancelAnimationFrame(resizeRafRef.current);
+        resizeRafRef.current = null;
+      }
+    };
   }, [fileType]); // fileType 전환 시 새 scroll container에 재부착
 
   // Ctrl+휠 줌 / 핀치 줌
@@ -47,12 +76,22 @@ export const FileRenderer = ({
     const el = scrollContainerRef.current;
     if (!el) return;
 
+    // DOM 직접 업데이트로 React re-render 없이 즉각 반응
+    const applyZoom = (z: number) => {
+      const clamped = Math.min(Math.max(z, 0.5), 3.0);
+      zoomRef.current = clamped;
+      if (zoomWrapperRef.current)
+        (
+          zoomWrapperRef.current.style as CSSStyleDeclaration & { zoom: string }
+        ).zoom = String(clamped);
+      setZoom(clamped); // React state 동기화 (다음 렌더 시 style override 방지)
+    };
+
     const onWheel = (e: WheelEvent) => {
       if (!e.ctrlKey) return;
       e.preventDefault();
-      setZoom((z) =>
-        Math.min(Math.max(z + (e.deltaY < 0 ? 0.1 : -0.1), 0.5), 3.0),
-      );
+      // 배율 방식: 한 스텝당 15% 변화
+      applyZoom(zoomRef.current * (e.deltaY < 0 ? 1.15 : 1 / 1.15));
     };
     const onTouchStart = (e: TouchEvent) => {
       if (e.touches.length === 2)
@@ -68,9 +107,7 @@ export const FileRenderer = ({
         e.touches[0].clientX - e.touches[1].clientX,
         e.touches[0].clientY - e.touches[1].clientY,
       );
-      setZoom((z) =>
-        Math.min(Math.max(z * (dist / lastTouchDistRef.current!), 0.5), 3.0),
-      );
+      applyZoom(zoomRef.current * (dist / lastTouchDistRef.current!));
       lastTouchDistRef.current = dist;
     };
     const onTouchEnd = () => {
@@ -108,7 +145,8 @@ export const FileRenderer = ({
         pdfRef.current = pdf;
         setNumPages(pdf.numPages);
         setPageNumber(1);
-        setZoom(1.0); // 파일 변경 시 zoom 초기화
+        zoomRef.current = 1.0;
+        setZoom(1.0);
       })
       .catch((err) => {
         if (!cancelled) {
@@ -147,7 +185,7 @@ export const FileRenderer = ({
         const naturalViewport = page.getViewport({ scale: 1.0 });
         const fitScale =
           containerWidth > 0
-            ? Math.max((containerWidth - 32) / naturalViewport.width, 0.1)
+            ? Math.max(contentWidth / naturalViewport.width, 0.1)
             : 1.0;
         const viewport = page.getViewport({ scale: fitScale });
         canvas.height = viewport.height;
@@ -178,7 +216,7 @@ export const FileRenderer = ({
         renderTaskRef.current.cancel();
       }
     };
-  }, [pageNumber, fileType, numPages, containerWidth]);
+  }, [pageNumber, fileType, numPages, containerWidth, contentWidth]);
 
   if (error) {
     return (
@@ -210,16 +248,20 @@ export const FileRenderer = ({
         >
           <div className="flex min-h-full min-w-max items-center justify-center p-4 pt-6">
             <div
+              ref={zoomWrapperRef}
               style={{
                 zoom,
-                width: containerWidth > 0 ? containerWidth - 32 : undefined,
+                width: containerWidth > 0 ? contentWidth : undefined,
               }}
             >
               <img
                 src={fileUrl}
                 alt={fileName}
                 className="block h-auto max-h-[80vh] w-full object-contain"
-                onLoad={() => setZoom(1.0)}
+                onLoad={() => {
+                  zoomRef.current = 1.0;
+                  setZoom(1.0);
+                }}
                 draggable={false}
               />
             </div>
@@ -293,12 +335,16 @@ export const FileRenderer = ({
         >
           <div className="flex min-h-full min-w-max justify-center p-4 pt-6">
             <div
+              ref={zoomWrapperRef}
               className="h-fit shadow-lg"
               style={{ zoom }}
             >
               <canvas
                 ref={canvasRef}
-                className="block bg-white"
+                className="block h-auto max-w-full bg-white"
+                style={{
+                  width: containerWidth > 0 ? contentWidth : undefined,
+                }}
                 draggable={false}
               />
             </div>

--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -7,6 +7,31 @@ import { LoadingSpinner } from "@/shared/components/loading-spinner";
 // Worker 설정 (로컬 번들 사용)
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
 
+const PDF_RENDER_QUALITY_SCALE = 2.5;
+const MAX_PDF_RENDER_PIXELS = 8_000_000;
+
+const getClientReachableUrl = (url: string) => {
+  if (typeof window === "undefined") return url;
+
+  try {
+    const parsedUrl = new URL(url);
+    const appHostName = window.location.hostname;
+    const isLocalDownloadHost =
+      parsedUrl.hostname === "localhost" || parsedUrl.hostname === "127.0.0.1";
+    const isRemoteClient =
+      appHostName !== "localhost" && appHostName !== "127.0.0.1";
+
+    if (isLocalDownloadHost && isRemoteClient) {
+      parsedUrl.hostname = appHostName;
+      return parsedUrl.toString();
+    }
+  } catch {
+    return url;
+  }
+
+  return url;
+};
+
 interface FileRendererProps {
   fileUrl: string | null;
   fileType: "pdf" | "image" | null;
@@ -35,6 +60,7 @@ export const FileRenderer = ({
   const resizeRafRef = useRef<number | null>(null);
 
   const contentWidth = Math.max(containerWidth - 32, 1);
+  const reachableFileUrl = fileUrl ? getClientReachableUrl(fileUrl) : null;
 
   // 컨테이너 너비 감지 → 다음 프레임에 반영해 드래그 중에도 즉시 크기 동기화
   useEffect(() => {
@@ -128,13 +154,13 @@ export const FileRenderer = ({
 
   // 1. PDF 문서 로드
   useEffect(() => {
-    if (!fileUrl || fileType !== "pdf") {
+    if (!reachableFileUrl || fileType !== "pdf") {
       pdfRef.current = null;
       return;
     }
 
     let cancelled = false;
-    const loadingTask = pdfjsLib.getDocument(fileUrl);
+    const loadingTask = pdfjsLib.getDocument(reachableFileUrl);
 
     loadingTask.promise
       .then((pdf) => {
@@ -160,7 +186,7 @@ export const FileRenderer = ({
       loadingTask.destroy();
       pdfRef.current = null;
     };
-  }, [fileUrl, fileType]);
+  }, [reachableFileUrl, fileType]);
 
   // 2. PDF 페이지 렌더링
   useEffect(() => {
@@ -188,13 +214,28 @@ export const FileRenderer = ({
             ? Math.max(contentWidth / naturalViewport.width, 0.1)
             : 1.0;
         const viewport = page.getViewport({ scale: fitScale });
-        canvas.height = viewport.height;
-        canvas.width = viewport.width;
+        const deviceScale = window.devicePixelRatio || 1;
+        const qualityScale = Math.max(deviceScale, PDF_RENDER_QUALITY_SCALE);
+        const maxScaleByPixels = Math.sqrt(
+          MAX_PDF_RENDER_PIXELS / (viewport.width * viewport.height),
+        );
+        const outputScale = Math.max(
+          1,
+          Math.min(qualityScale, maxScaleByPixels),
+        );
+        canvas.height = Math.floor(viewport.height * outputScale);
+        canvas.width = Math.floor(viewport.width * outputScale);
+        canvas.style.height = `${viewport.height}px`;
+        canvas.style.width = `${viewport.width}px`;
 
         const renderTask = page.render({
           canvas: canvas,
           canvasContext: canvas.getContext("2d")!,
           viewport: viewport,
+          transform:
+            outputScale === 1
+              ? undefined
+              : [outputScale, 0, 0, outputScale, 0, 0],
         });
         renderTaskRef.current = renderTask;
 
@@ -232,7 +273,7 @@ export const FileRenderer = ({
     );
   }
 
-  if (fileType === "image" && fileUrl) {
+  if (fileType === "image" && reachableFileUrl) {
     return (
       <div className="flex h-full flex-col bg-gray-100">
         {/* 네비게이션 바 (이미지용 - 페이지 컨트롤 없음) */}
@@ -255,12 +296,15 @@ export const FileRenderer = ({
               }}
             >
               <img
-                src={fileUrl}
+                src={reachableFileUrl}
                 alt={fileName}
                 className="block h-auto max-h-[80vh] w-full object-contain"
                 onLoad={() => {
                   zoomRef.current = 1.0;
                   setZoom(1.0);
+                }}
+                onError={() => {
+                  setError("이미지를 불러오는 중 오류가 발생했습니다.");
                 }}
                 draggable={false}
               />

--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -20,12 +20,74 @@ export const FileRenderer = ({
 }: FileRendererProps) => {
   const [pageNumber, setPageNumber] = useState(1);
   const [numPages, setNumPages] = useState<number | null>(null);
-  const [scale] = useState(1.0);
+  const [containerWidth, setContainerWidth] = useState(0);
   const [error, setError] = useState<string | null>(null);
+
+  const [zoom, setZoom] = useState(1.0);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const lastTouchDistRef = useRef<number | null>(null);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const renderTaskRef = useRef<RenderTask | null>(null);
   const pdfRef = useRef<PDFDocumentProxy | null>(null);
+
+  // 컨테이너 너비 감지 → 캔버스 base scale 계산에 사용
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      setContainerWidth(entries[0].contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [fileType]); // fileType 전환 시 새 scroll container에 재부착
+
+  // Ctrl+휠 줌 / 핀치 줌
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      setZoom((z) =>
+        Math.min(Math.max(z + (e.deltaY < 0 ? 0.1 : -0.1), 0.5), 3.0),
+      );
+    };
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 2)
+        lastTouchDistRef.current = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY,
+        );
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 2 || lastTouchDistRef.current === null) return;
+      e.preventDefault();
+      const dist = Math.hypot(
+        e.touches[0].clientX - e.touches[1].clientX,
+        e.touches[0].clientY - e.touches[1].clientY,
+      );
+      setZoom((z) =>
+        Math.min(Math.max(z * (dist / lastTouchDistRef.current!), 0.5), 3.0),
+      );
+      lastTouchDistRef.current = dist;
+    };
+    const onTouchEnd = () => {
+      lastTouchDistRef.current = null;
+    };
+
+    el.addEventListener("wheel", onWheel, { passive: false });
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+    el.addEventListener("touchend", onTouchEnd);
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [fileType]);
 
   // 1. PDF 문서 로드
   useEffect(() => {
@@ -45,7 +107,8 @@ export const FileRenderer = ({
         }
         pdfRef.current = pdf;
         setNumPages(pdf.numPages);
-        setPageNumber(1); // 파일 변경 시 페이지 초기화
+        setPageNumber(1);
+        setZoom(1.0); // 파일 변경 시 zoom 초기화
       })
       .catch((err) => {
         if (!cancelled) {
@@ -80,7 +143,13 @@ export const FileRenderer = ({
         const canvas = canvasRef.current;
         if (!canvas) return;
 
-        const viewport = page.getViewport({ scale });
+        // 컨테이너 너비에 맞는 base scale 계산 (padding 32px 제외)
+        const naturalViewport = page.getViewport({ scale: 1.0 });
+        const fitScale =
+          containerWidth > 0
+            ? Math.max((containerWidth - 32) / naturalViewport.width, 0.1)
+            : 1.0;
+        const viewport = page.getViewport({ scale: fitScale });
         canvas.height = viewport.height;
         canvas.width = viewport.width;
 
@@ -109,7 +178,7 @@ export const FileRenderer = ({
         renderTaskRef.current.cancel();
       }
     };
-  }, [pageNumber, scale, fileType, numPages]); // fileType 의존성 추가 (이미지 -> PDF 전환 시 필요)
+  }, [pageNumber, fileType, numPages, containerWidth]);
 
   if (error) {
     return (
@@ -135,13 +204,26 @@ export const FileRenderer = ({
           </span>
         </div>
 
-        <div className="flex min-h-0 flex-1 items-start justify-center overflow-auto bg-gray-50 p-4 pt-6">
-          <img
-            src={fileUrl}
-            alt={fileName}
-            className="h-full w-full object-contain"
-            draggable={false}
-          />
+        <div
+          ref={scrollContainerRef}
+          className="min-h-0 flex-1 overflow-auto bg-gray-50"
+        >
+          <div className="flex min-h-full min-w-max items-center justify-center p-4 pt-6">
+            <div
+              style={{
+                zoom,
+                width: containerWidth > 0 ? containerWidth - 32 : undefined,
+              }}
+            >
+              <img
+                src={fileUrl}
+                alt={fileName}
+                className="block h-auto max-h-[80vh] w-full object-contain"
+                onLoad={() => setZoom(1.0)}
+                draggable={false}
+              />
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -204,14 +286,22 @@ export const FileRenderer = ({
           </div>
         </div>
 
-        {/* 캔버스 영역 */}
-        <div className="flex min-h-0 flex-1 justify-center overflow-y-auto bg-gray-50 p-4 pt-6">
-          <div className="h-fit shadow-lg">
-            <canvas
-              ref={canvasRef}
-              className="block h-auto max-w-full bg-white"
-              draggable={false}
-            />
+        {/* 캔버스 영역 — 줌 시 overflow 스크롤 가능하도록 레이아웃 분리 */}
+        <div
+          ref={scrollContainerRef}
+          className="min-h-0 flex-1 overflow-auto bg-gray-50"
+        >
+          <div className="flex min-h-full min-w-max justify-center p-4 pt-6">
+            <div
+              className="h-fit shadow-lg"
+              style={{ zoom }}
+            >
+              <canvas
+                ref={canvasRef}
+                className="block bg-white"
+                draggable={false}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -129,8 +129,8 @@ export const FileRenderer = ({
     return (
       <div className="flex h-full flex-col bg-gray-100">
         {/* 네비게이션 바 (이미지용 - 페이지 컨트롤 없음) */}
-        <div className="flex shrink-0 items-center justify-between border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
-          <span className="truncate text-sm font-medium text-gray-700">
+        <div className="flex shrink-0 items-center justify-center border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
+          <span className="truncate text-center font-[Pretendard] text-[18px] leading-7 font-semibold tracking-[-0.002px] text-black">
             {fileName}
           </span>
         </div>
@@ -151,19 +151,32 @@ export const FileRenderer = ({
     return (
       <div className="flex h-full flex-col bg-gray-100">
         {/* 네비게이션 바 */}
-        <div className="flex shrink-0 items-center justify-between border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
-          <span className="truncate text-sm font-medium text-gray-700">
-            {fileName} (PDF)
+        <div className="flex shrink-0 items-center gap-2 border-b border-[#D1D6DE] bg-white px-4 py-2 shadow-sm">
+          <span className="min-w-0 flex-1 truncate text-center font-[Pretendard] text-[18px] leading-7 font-semibold tracking-[-0.002px] text-black">
+            {fileName}
           </span>
-          <div className="flex items-center gap-2 text-sm text-gray-500">
+          <div className="flex shrink-0 items-center gap-1 text-[14px] font-semibold text-black">
             <button
               onClick={() => setPageNumber((prev) => Math.max(prev - 1, 1))}
               disabled={pageNumber <= 1}
               className="cursor-pointer rounded p-1 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
             >
-              {"<"}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M11.2931 8.29279C11.4806 8.10532 11.7349 8 12.0001 8C12.2652 8 12.5195 8.10532 12.7071 8.29279L18.3641 13.9498C18.5462 14.1384 18.647 14.391 18.6447 14.6532C18.6425 14.9154 18.5373 15.1662 18.3519 15.3516C18.1665 15.537 17.9157 15.6422 17.6535 15.6445C17.3913 15.6467 17.1387 15.5459 16.9501 15.3638L12.0001 10.4138L7.05006 15.3638C6.86146 15.5459 6.60885 15.6467 6.34666 15.6445C6.08446 15.6422 5.83365 15.537 5.64824 15.3516C5.46283 15.1662 5.35766 14.9154 5.35538 14.6532C5.35311 14.391 5.4539 14.1384 5.63606 13.9498L11.2931 8.29279Z"
+                  fill="#999999"
+                />
+              </svg>
             </button>
-            <span>
+            <span className="shrink-0 px-1">
               {pageNumber} / {numPages || "-"}
             </span>
             <button
@@ -173,7 +186,20 @@ export const FileRenderer = ({
               disabled={!numPages || pageNumber >= numPages}
               className="cursor-pointer rounded p-1 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
             >
-              {">"}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="8"
+                viewBox="0 0 14 8"
+                fill="none"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M7.37629 7.37629C7.18876 7.56376 6.93445 7.66907 6.66929 7.66907C6.40412 7.66907 6.14982 7.56376 5.96229 7.37629L0.305288 1.71929C0.209778 1.62704 0.133596 1.5167 0.0811869 1.39469C0.0287779 1.27269 0.00119157 1.14147 3.77564e-05 1.00869C-0.00111606 0.87591 0.0241859 0.744231 0.0744668 0.621335C0.124748 0.498438 0.199001 0.386786 0.292893 0.292893C0.386786 0.199 0.498438 0.124747 0.621334 0.0744663C0.744231 0.0241854 0.87591 -0.00111606 1.00869 3.77571e-05C1.14147 0.00119157 1.27269 0.0287779 1.39469 0.0811869C1.5167 0.133596 1.62704 0.209778 1.71929 0.305288L6.66929 5.25529L11.6193 0.305288C11.8079 0.12313 12.0605 0.0223355 12.3227 0.0246139C12.5849 0.0268924 12.8357 0.132061 13.0211 0.317469C13.2065 0.502877 13.3117 0.75369 13.314 1.01589C13.3162 1.27808 13.2154 1.53069 13.0333 1.71929L7.37629 7.37629Z"
+                  fill="black"
+                />
+              </svg>
             </button>
           </div>
         </div>

--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -159,7 +159,7 @@ export const FileRenderer = ({
             <button
               onClick={() => setPageNumber((prev) => Math.max(prev - 1, 1))}
               disabled={pageNumber <= 1}
-              className="cursor-pointer rounded p-1 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
+              className="flex h-8 w-8 cursor-pointer items-center justify-center rounded hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -172,7 +172,7 @@ export const FileRenderer = ({
                   fillRule="evenodd"
                   clipRule="evenodd"
                   d="M11.2931 8.29279C11.4806 8.10532 11.7349 8 12.0001 8C12.2652 8 12.5195 8.10532 12.7071 8.29279L18.3641 13.9498C18.5462 14.1384 18.647 14.391 18.6447 14.6532C18.6425 14.9154 18.5373 15.1662 18.3519 15.3516C18.1665 15.537 17.9157 15.6422 17.6535 15.6445C17.3913 15.6467 17.1387 15.5459 16.9501 15.3638L12.0001 10.4138L7.05006 15.3638C6.86146 15.5459 6.60885 15.6467 6.34666 15.6445C6.08446 15.6422 5.83365 15.537 5.64824 15.3516C5.46283 15.1662 5.35766 14.9154 5.35538 14.6532C5.35311 14.391 5.4539 14.1384 5.63606 13.9498L11.2931 8.29279Z"
-                  fill="#999999"
+                  fill="black"
                 />
               </svg>
             </button>
@@ -184,7 +184,7 @@ export const FileRenderer = ({
                 setPageNumber((prev) => Math.min(prev + 1, numPages || prev))
               }
               disabled={!numPages || pageNumber >= numPages}
-              className="cursor-pointer rounded p-1 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
+              className="flex h-8 w-8 cursor-pointer items-center justify-center rounded hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/features/chat/components/leftpanel/FileRenderer.tsx
+++ b/src/features/chat/components/leftpanel/FileRenderer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as pdfjsLib from "pdfjs-dist";
 import type { RenderTask, PDFDocumentProxy } from "pdfjs-dist";
 import pdfjsWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
@@ -38,6 +38,99 @@ interface FileRendererProps {
   fileName: string;
 }
 
+interface PdfPageCanvasProps {
+  pdf: PDFDocumentProxy;
+  pageNumber: number;
+  contentWidth: number;
+  onRenderError: () => void;
+}
+
+const PdfPageCanvas = ({
+  pdf,
+  pageNumber,
+  contentWidth,
+  onRenderError,
+}: PdfPageCanvasProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const renderTaskRef = useRef<RenderTask | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const renderPage = async () => {
+      try {
+        if (renderTaskRef.current) {
+          renderTaskRef.current.cancel();
+        }
+
+        const page = await pdf.getPage(pageNumber);
+        if (cancelled) return;
+
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        const naturalViewport = page.getViewport({ scale: 1.0 });
+        const fitScale = Math.max(contentWidth / naturalViewport.width, 0.1);
+        const viewport = page.getViewport({ scale: fitScale });
+        const deviceScale = window.devicePixelRatio || 1;
+        const qualityScale = Math.max(deviceScale, PDF_RENDER_QUALITY_SCALE);
+        const maxScaleByPixels = Math.sqrt(
+          MAX_PDF_RENDER_PIXELS / (viewport.width * viewport.height),
+        );
+        const outputScale = Math.max(
+          1,
+          Math.min(qualityScale, maxScaleByPixels),
+        );
+
+        canvas.height = Math.floor(viewport.height * outputScale);
+        canvas.width = Math.floor(viewport.width * outputScale);
+        canvas.style.height = `${viewport.height}px`;
+        canvas.style.width = `${viewport.width}px`;
+
+        const canvasContext = canvas.getContext("2d");
+        if (!canvasContext) return;
+
+        const renderTask = page.render({
+          canvas,
+          canvasContext,
+          viewport,
+          transform:
+            outputScale === 1
+              ? undefined
+              : [outputScale, 0, 0, outputScale, 0, 0],
+        });
+        renderTaskRef.current = renderTask;
+
+        await renderTask.promise;
+      } catch (err: unknown) {
+        const renderErr = err as { name?: string };
+        if (renderErr.name !== "RenderingCancelledException" && !cancelled) {
+          console.error("PDF 렌더링 오류:", err);
+          onRenderError();
+        }
+      }
+    };
+
+    renderPage();
+
+    return () => {
+      cancelled = true;
+      if (renderTaskRef.current) {
+        renderTaskRef.current.cancel();
+      }
+    };
+  }, [contentWidth, onRenderError, pageNumber, pdf]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="block h-auto max-w-full bg-white shadow-lg"
+      style={{ width: contentWidth }}
+      draggable={false}
+    />
+  );
+};
+
 export const FileRenderer = ({
   fileUrl,
   fileType,
@@ -45,6 +138,10 @@ export const FileRenderer = ({
 }: FileRendererProps) => {
   const [pageNumber, setPageNumber] = useState(1);
   const [numPages, setNumPages] = useState<number | null>(null);
+  const [pdfDoc, setPdfDoc] = useState<{
+    url: string;
+    doc: PDFDocumentProxy;
+  } | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
@@ -53,14 +150,16 @@ export const FileRenderer = ({
   const zoomWrapperRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const lastTouchDistRef = useRef<number | null>(null);
-
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const renderTaskRef = useRef<RenderTask | null>(null);
-  const pdfRef = useRef<PDFDocumentProxy | null>(null);
+  const pageRefs = useRef<Array<HTMLDivElement | null>>([]);
   const resizeRafRef = useRef<number | null>(null);
+  const scrollRafRef = useRef<number | null>(null);
+  const programmaticScrollPageRef = useRef<number | null>(null);
+  const programmaticScrollTimeoutRef = useRef<number | null>(null);
 
   const contentWidth = Math.max(containerWidth - 32, 1);
   const reachableFileUrl = fileUrl ? getClientReachableUrl(fileUrl) : null;
+  const activePdfDoc =
+    pdfDoc?.url === reachableFileUrl && fileType === "pdf" ? pdfDoc.doc : null;
 
   // 컨테이너 너비 감지 → 다음 프레임에 반영해 드래그 중에도 즉시 크기 동기화
   useEffect(() => {
@@ -155,7 +254,6 @@ export const FileRenderer = ({
   // 1. PDF 문서 로드
   useEffect(() => {
     if (!reachableFileUrl || fileType !== "pdf") {
-      pdfRef.current = null;
       return;
     }
 
@@ -168,9 +266,10 @@ export const FileRenderer = ({
           pdf.destroy();
           return;
         }
-        pdfRef.current = pdf;
+        setPdfDoc({ url: reachableFileUrl, doc: pdf });
         setNumPages(pdf.numPages);
         setPageNumber(1);
+        pageRefs.current = [];
         zoomRef.current = 1.0;
         setZoom(1.0);
       })
@@ -184,80 +283,97 @@ export const FileRenderer = ({
     return () => {
       cancelled = true;
       loadingTask.destroy();
-      pdfRef.current = null;
     };
   }, [reachableFileUrl, fileType]);
 
-  // 2. PDF 페이지 렌더링
+  const handlePdfRenderError = useCallback(() => {
+    setError("PDF를 불러오는 중 오류가 발생했습니다.");
+  }, []);
+
+  const getVisiblePdfPage = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !numPages) return null;
+
+    const containerRect = container.getBoundingClientRect();
+    const readPoint = containerRect.top + containerRect.height * 0.35;
+
+    let closestPage = 1;
+    let closestDistance = Number.POSITIVE_INFINITY;
+
+    pageRefs.current.forEach((pageEl, index) => {
+      if (!pageEl) return;
+      const pageRect = pageEl.getBoundingClientRect();
+      const pageCenter = pageRect.top + pageRect.height / 2;
+      const distance = Math.abs(pageCenter - readPoint);
+
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        closestPage = index + 1;
+      }
+    });
+
+    return closestPage;
+  }, [numPages]);
+
+  const updatePageNumberFromScroll = useCallback(() => {
+    const closestPage = getVisiblePdfPage();
+    if (closestPage === null) return;
+
+    setPageNumber((prev) => (prev === closestPage ? prev : closestPage));
+  }, [getVisiblePdfPage]);
+
+  const handlePdfScroll = useCallback(() => {
+    if (scrollRafRef.current !== null) return;
+
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      const programmaticPage = programmaticScrollPageRef.current;
+
+      if (programmaticPage !== null) {
+        if (getVisiblePdfPage() === programmaticPage) {
+          programmaticScrollPageRef.current = null;
+        }
+        return;
+      }
+
+      updatePageNumberFromScroll();
+    });
+  }, [getVisiblePdfPage, updatePageNumberFromScroll]);
+
   useEffect(() => {
-    const pdf = pdfRef.current;
-    if (!pdf || fileType !== "pdf") return;
-
-    let cancelled = false;
-
-    const renderPage = async () => {
-      try {
-        if (renderTaskRef.current) {
-          renderTaskRef.current.cancel();
-        }
-
-        const page = await pdf.getPage(pageNumber);
-        if (cancelled) return;
-
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-
-        // 컨테이너 너비에 맞는 base scale 계산 (padding 32px 제외)
-        const naturalViewport = page.getViewport({ scale: 1.0 });
-        const fitScale =
-          containerWidth > 0
-            ? Math.max(contentWidth / naturalViewport.width, 0.1)
-            : 1.0;
-        const viewport = page.getViewport({ scale: fitScale });
-        const deviceScale = window.devicePixelRatio || 1;
-        const qualityScale = Math.max(deviceScale, PDF_RENDER_QUALITY_SCALE);
-        const maxScaleByPixels = Math.sqrt(
-          MAX_PDF_RENDER_PIXELS / (viewport.width * viewport.height),
-        );
-        const outputScale = Math.max(
-          1,
-          Math.min(qualityScale, maxScaleByPixels),
-        );
-        canvas.height = Math.floor(viewport.height * outputScale);
-        canvas.width = Math.floor(viewport.width * outputScale);
-        canvas.style.height = `${viewport.height}px`;
-        canvas.style.width = `${viewport.width}px`;
-
-        const renderTask = page.render({
-          canvas: canvas,
-          canvasContext: canvas.getContext("2d")!,
-          viewport: viewport,
-          transform:
-            outputScale === 1
-              ? undefined
-              : [outputScale, 0, 0, outputScale, 0, 0],
-        });
-        renderTaskRef.current = renderTask;
-
-        await renderTask.promise;
-      } catch (err: unknown) {
-        const renderErr = err as { name?: string };
-        if (renderErr.name !== "RenderingCancelledException" && !cancelled) {
-          console.error("PDF 렌더링 오류:", err);
-          setError("PDF를 불러오는 중 오류가 발생했습니다.");
-        }
-      }
-    };
-
-    renderPage();
-
     return () => {
-      cancelled = true;
-      if (renderTaskRef.current) {
-        renderTaskRef.current.cancel();
+      if (scrollRafRef.current !== null) {
+        cancelAnimationFrame(scrollRafRef.current);
+        scrollRafRef.current = null;
+      }
+      if (programmaticScrollTimeoutRef.current !== null) {
+        window.clearTimeout(programmaticScrollTimeoutRef.current);
+        programmaticScrollTimeoutRef.current = null;
       }
     };
-  }, [pageNumber, fileType, numPages, containerWidth, contentWidth]);
+  }, []);
+
+  const scrollToPage = useCallback(
+    (nextPage: number) => {
+      if (!numPages) return;
+      const clampedPage = Math.min(Math.max(nextPage, 1), numPages);
+      programmaticScrollPageRef.current = clampedPage;
+      if (programmaticScrollTimeoutRef.current !== null) {
+        window.clearTimeout(programmaticScrollTimeoutRef.current);
+      }
+      programmaticScrollTimeoutRef.current = window.setTimeout(() => {
+        programmaticScrollPageRef.current = null;
+        programmaticScrollTimeoutRef.current = null;
+        updatePageNumberFromScroll();
+      }, 700);
+      setPageNumber(clampedPage);
+      pageRefs.current[clampedPage - 1]?.scrollIntoView({
+        block: "start",
+        behavior: "smooth",
+      });
+    },
+    [numPages, updatePageNumberFromScroll],
+  );
 
   if (error) {
     return (
@@ -325,7 +441,7 @@ export const FileRenderer = ({
           </span>
           <div className="flex shrink-0 items-center gap-1 text-[14px] font-semibold text-black">
             <button
-              onClick={() => setPageNumber((prev) => Math.max(prev - 1, 1))}
+              onClick={() => scrollToPage(pageNumber - 1)}
               disabled={pageNumber <= 1}
               className="flex h-8 w-8 cursor-pointer items-center justify-center rounded hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
             >
@@ -348,9 +464,7 @@ export const FileRenderer = ({
               {pageNumber} / {numPages || "-"}
             </span>
             <button
-              onClick={() =>
-                setPageNumber((prev) => Math.min(prev + 1, numPages || prev))
-              }
+              onClick={() => scrollToPage(pageNumber + 1)}
               disabled={!numPages || pageNumber >= numPages}
               className="flex h-8 w-8 cursor-pointer items-center justify-center rounded hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
             >
@@ -375,22 +489,44 @@ export const FileRenderer = ({
         {/* 캔버스 영역 — 줌 시 overflow 스크롤 가능하도록 레이아웃 분리 */}
         <div
           ref={scrollContainerRef}
+          onScroll={handlePdfScroll}
           className="min-h-0 flex-1 overflow-auto bg-gray-50"
         >
-          <div className="flex min-h-full min-w-max justify-center p-4 pt-6">
+          <div className="flex min-h-full min-w-max justify-center p-4 pt-6 pb-10">
             <div
               ref={zoomWrapperRef}
-              className="h-fit shadow-lg"
+              className="flex h-fit flex-col gap-4"
               style={{ zoom }}
             >
-              <canvas
-                ref={canvasRef}
-                className="block h-auto max-w-full bg-white"
-                style={{
-                  width: containerWidth > 0 ? contentWidth : undefined,
-                }}
-                draggable={false}
-              />
+              {activePdfDoc && numPages ? (
+                Array.from({ length: numPages }, (_, index) => {
+                  const pdfPageNumber = index + 1;
+
+                  return (
+                    <div
+                      key={pdfPageNumber}
+                      ref={(el) => {
+                        pageRefs.current[index] = el;
+                      }}
+                      className="scroll-mt-4"
+                    >
+                      <PdfPageCanvas
+                        pdf={activePdfDoc}
+                        pageNumber={pdfPageNumber}
+                        contentWidth={contentWidth}
+                        onRenderError={handlePdfRenderError}
+                      />
+                    </div>
+                  );
+                })
+              ) : (
+                <div
+                  className="flex items-center justify-center"
+                  style={{ width: contentWidth, minHeight: 360 }}
+                >
+                  <LoadingSpinner size={40} />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/features/chat/components/leftpanel/ViewerContent.tsx
+++ b/src/features/chat/components/leftpanel/ViewerContent.tsx
@@ -12,8 +12,8 @@ import {
   PLAN_DETAILS,
   type PlanType,
 } from "@/features/subscription/types/plan_types";
-import { DragDropOverlay } from "@/features/editor/components/input/DragDropOverlay";
-import { ViewerEmpty } from "./ViewerEmpty";
+
+import { ViewerUploadCard } from "@/pages/components/ViewerUploadCard";
 import { FileRenderer } from "./FileRenderer";
 import { parseSize } from "@/shared/utils/file-utils";
 import { showErrorToast } from "@/shared/lib/toast";
@@ -181,7 +181,23 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
   const renderContent = () => {
     // Case 1: 파일이 선택되지 않음 -> 업로드 UI (Empty State)
     if (!activeFileId) {
-      return <ViewerEmpty onOpenFileExplorer={openFileExplorer} />;
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-6">
+          <ViewerUploadCard
+            pdfUrl={null}
+            fileName=""
+            fileInputRef={fileInputRef}
+            onFileChange={handleFileChange}
+            onOpenExplorer={openFileExplorer}
+            onRemove={() => {}}
+            isDragging={isDragging}
+            dragProps={dragProps}
+          />
+          <p className="text-center font-[Pretendard] text-[16px] leading-6 font-normal whitespace-pre-line text-[#6B7280]">
+            {"파일이 비어있습니다.\n파일을 끌어오거나 클릭해서 추가해 주세요."}
+          </p>
+        </div>
+      );
     }
 
     // Case 2: 로딩 중
@@ -219,10 +235,7 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
   };
 
   return (
-    <div
-      className="relative h-full w-full"
-      {...dragProps}
-    >
+    <div className="relative h-full w-full">
       <input
         type="file"
         ref={fileInputRef}
@@ -230,9 +243,6 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
         onChange={handleFileChange}
         accept={FILE_ACCEPT}
       />
-
-      {/* Drag Overlay */}
-      {isDragging && <DragDropOverlay />}
 
       {renderContent()}
     </div>

--- a/src/features/chat/components/leftpanel/ViewerContent.tsx
+++ b/src/features/chat/components/leftpanel/ViewerContent.tsx
@@ -234,17 +234,5 @@ export const ViewerContent = ({ noteId, fileId }: ViewerContentProps) => {
     );
   };
 
-  return (
-    <div className="relative h-full w-full">
-      <input
-        type="file"
-        ref={fileInputRef}
-        className="hidden"
-        onChange={handleFileChange}
-        accept={FILE_ACCEPT}
-      />
-
-      {renderContent()}
-    </div>
-  );
+  return <div className="relative h-full w-full">{renderContent()}</div>;
 };

--- a/src/features/notes/hooks/useNotes.ts
+++ b/src/features/notes/hooks/useNotes.ts
@@ -23,7 +23,10 @@ import type {
 export const noteKeys = {
   all: ["notes"] as const,
   lists: () => [...noteKeys.all, "list"] as const,
-  list: (params?: NoteListParams) => [...noteKeys.lists(), params] as const,
+  list: (params?: NoteListParams) =>
+    [...noteKeys.lists(), "paginated", params] as const,
+  infiniteList: (params?: Omit<NoteListParams, "page" | "cursor">) =>
+    [...noteKeys.lists(), "infinite", params] as const,
   detail: (id: string, params?: NoteDetailParams) =>
     [...noteKeys.all, "detail", id, params] as const,
 };
@@ -50,7 +53,7 @@ export const useInfiniteNoteList = (
   params?: Omit<NoteListParams, "page" | "cursor">,
 ) => {
   return useInfiniteQuery({
-    queryKey: noteKeys.list(params),
+    queryKey: noteKeys.infiniteList(params),
     queryFn: async ({ pageParam }) => {
       const response = await getNoteList({
         ...params,

--- a/src/pages/components/ViewerUploadCard.tsx
+++ b/src/pages/components/ViewerUploadCard.tsx
@@ -96,7 +96,7 @@ export const ViewerUploadCard = ({
       <button
         onClick={onOpenExplorer}
         type="button"
-        className="group flex h-[160px] w-full shrink-0 cursor-pointer flex-col items-center justify-center gap-[16px] rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white/40 px-[20px] py-[24px] shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-colors duration-700 hover:bg-[#2A6AFF33] active:bg-[#2A6AFF33] lg:w-[220px]"
+        className="group flex h-[160px] w-full shrink-0 cursor-pointer flex-col items-center justify-center gap-[16px] rounded-[12px] border-[0.5px] border-[#C6C6C6] bg-white/40 px-[20px] py-[24px] shadow-[4px_4px_20px_5px_rgba(0,0,0,0.05)] transition-colors duration-500 hover:bg-[#2A6AFF33] active:bg-[#2A6AFF33] lg:w-[220px]"
       >
         <div>
           <PdfIcon size={56} />

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import type { AxiosError, InternalAxiosRequestConfig } from "axios";
 import type { ApiResponse, TokenDto } from "./shared_types";
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
 
 // 토큰 저장 키
 const ACCESS_TOKEN_KEY = "accessToken";


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #276

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 🗑️ 코드 제거 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 빈 상태 UI를 홈 화면과 동일한 `ViewerUploadCard` 컴포넌트로 교체 (중앙 정렬)
- 드래그 앤 드롭 범위를 Viewer 전체 패널 → 카드 영역으로 한정
- 파일 제목 상단 중앙 정렬 및 Figma 폰트 스펙 적용 (Pretendard 18px / 600 / leading-7)
- PDF 페이지 이동 버튼을 텍스트(`<`, `>`) → SVG 아이콘으로 교체, hover 영역 및 색상 통일
- PDF/이미지 패널 축소 시 콘텐츠도 함께 줄어들도록 반응형 처리
- Ctrl+휠(데스크탑) / 핀치(모바일) 확대·축소 기능 추가, 줌 시 스크롤 가능
- 줌 인터랙션 DOM 직접 업데이트로 즉각 반응, 배율 방식(15%)으로 자연스러운 줌감
- PDF 렌더링 품질 개선 (HiDPI 대응, 픽셀 예산 캡 적용)
- ResizeObserver rAF 배칭으로 리사이즈 버벅임 최소화

## 📸 스크린샷 (UI 변경 시 필수)


https://github.com/user-attachments/assets/a4649a6f-5446-4f1a-9920-79d2d7a83f9d



## ✅ 체크리스트

### 공통

- [x] 셀프 리뷰를 완료했습니다
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] `pnpm tsc --noEmit` 타입 체크를 통과했습니다
- [x] 브랜치명 컨벤션을 준수했습니다 (`type/이슈번호-작업명`)

### UI/레이아웃 변경 시

- [x] 태블릿(768px~) / 데스크탑(1280px~) / 와이드(1360px~) 반응형을 확인했습니다
- [ ] `PageContainer` / `ContentGrid` 공통 컴포넌트를 활용했습니다

## 📎 기타 참고사항

- Ctrl+휠 줌 시 브라우저 기본 확대 동작은 `e.preventDefault()`로 차단
- PDF 렌더링은 `PDF_RENDER_QUALITY_SCALE = 2.5` 기준, `MAX_PDF_RENDER_PIXELS = 8_000_000` 픽셀 예산 내에서 동적 조정
- `useNotes.ts` 무한 스크롤 쿼리 키 분리 및 `client.ts` BASE_URL 폴백 처리 포함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 파일 뷰어에서 PDF/이미지의 줌 및 핀치 확대 지원
  * 컨테이너에 맞춘 동적 스케일링으로 화면 최적화 렌더링
  * 파일 업로드 UI 개선: 업로드 카드 중심 드래그앤드롭 처리 및 빈 상태 교체
  * 노트 목록 무한 스크롤 지원 추가

* **Style**
  * 업로드 버튼 호버/액티브 애니메이션 속도 개선

* **Chores**
  * API 연결 기본값 개선으로 안정성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Proovy/Proovy-front/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->