### PR TITLE
Fix(#278): 사이드바 개선

### DIFF
--- a/src/features/sidebar/Sidebar.tsx
+++ b/src/features/sidebar/Sidebar.tsx
@@ -50,7 +50,7 @@ export const Sidebar = ({
           />
 
           {/* 메인 메뉴 영역 (고정) */}
-          <nav className="mb-[52px] flex w-[240px] shrink-0 flex-col gap-[12px] py-3">
+          <nav className="mb-[24px] flex w-[240px] shrink-0 flex-col gap-[12px] py-3">
             <NavItem
               to="/app/home"
               icon={HomeIcon}

--- a/src/features/sidebar/components/RecentNotes.tsx
+++ b/src/features/sidebar/components/RecentNotes.tsx
@@ -196,7 +196,7 @@ export const RecentNotes = ({ isCollapsed }: RecentNotesProps) => {
       {/* 단건 삭제 확인 모달 */}
       {deleteTargetId !== null && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-[#00000033]"
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-[#00000033]"
           onClick={(e) => {
             if (e.target === e.currentTarget && !isDeleting) {
               setDeleteTargetId(null);

--- a/src/features/sidebar/components/RecentNotes.tsx
+++ b/src/features/sidebar/components/RecentNotes.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import {
   useInfiniteNoteList,
   useDeleteNote,
@@ -193,42 +194,44 @@ export const RecentNotes = ({ isCollapsed }: RecentNotesProps) => {
         </ul>
       </div>
 
-      {/* 단건 삭제 확인 모달 */}
-      {deleteTargetId !== null && (
-        <div
-          className="fixed inset-0 z-[9999] flex items-center justify-center bg-[#00000033]"
-          onClick={(e) => {
-            if (e.target === e.currentTarget && !isDeleting) {
-              setDeleteTargetId(null);
-            }
-          }}
-        >
-          <div className="w-[360px] rounded-[20px] bg-white px-8 py-8 shadow-[0px_10px_40px_rgba(0,0,0,0.1)]">
-            <h2 className="text-center text-[22px] leading-[32px] font-semibold text-black">
-              이 노트를 삭제하시겠습니까?
-            </h2>
-            <p className="mt-3 text-center text-[15px] text-[#00000066]">
-              삭제된 노트는 복구가 불가능합니다.
-            </p>
-            <div className="mt-6 flex gap-3">
-              <button
-                onClick={() => setDeleteTargetId(null)}
-                disabled={isDeleting}
-                className="flex h-[48px] flex-1 items-center justify-center rounded-[16px] border border-[#D1D6DE] bg-[#F1F4F8] text-[16px] font-semibold text-[#6B7280] disabled:opacity-50"
-              >
-                취소
-              </button>
-              <button
-                onClick={handleDeleteConfirm}
-                disabled={isDeleting}
-                className="flex h-[48px] flex-1 items-center justify-center rounded-[16px] bg-[#2A6AFF] text-[16px] font-semibold text-white disabled:opacity-70"
-              >
-                {isDeleting ? "삭제 중..." : "삭제"}
-              </button>
+      {/* 단건 삭제 확인 모달 — portal로 body에 마운트해 stacking context 우회 */}
+      {deleteTargetId !== null &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[9999] flex items-center justify-center bg-[#00000033]"
+            onClick={(e) => {
+              if (e.target === e.currentTarget && !isDeleting) {
+                setDeleteTargetId(null);
+              }
+            }}
+          >
+            <div className="w-[360px] rounded-[20px] bg-white px-8 py-8 shadow-[0px_10px_40px_rgba(0,0,0,0.1)]">
+              <h2 className="text-center text-[22px] leading-[32px] font-semibold text-black">
+                이 노트를 삭제하시겠습니까?
+              </h2>
+              <p className="mt-3 text-center text-[15px] text-[#00000066]">
+                삭제된 노트는 복구가 불가능합니다.
+              </p>
+              <div className="mt-6 flex gap-3">
+                <button
+                  onClick={() => setDeleteTargetId(null)}
+                  disabled={isDeleting}
+                  className="flex h-[48px] flex-1 items-center justify-center rounded-[16px] border border-[#D1D6DE] bg-[#F1F4F8] text-[16px] font-semibold text-[#6B7280] disabled:opacity-50"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={handleDeleteConfirm}
+                  disabled={isDeleting}
+                  className="flex h-[48px] flex-1 items-center justify-center rounded-[16px] bg-[#2A6AFF] text-[16px] font-semibold text-white disabled:opacity-70"
+                >
+                  {isDeleting ? "삭제 중..." : "삭제"}
+                </button>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </>
   );
 };

--- a/src/features/sidebar/components/SidebarNoteItem.tsx
+++ b/src/features/sidebar/components/SidebarNoteItem.tsx
@@ -90,8 +90,10 @@ export const SidebarNoteItem = ({
           to={`/app/chat/${note.noteId}`}
           state={{ chatEntrySource: "sidebar-recent-notes" }}
           className={({ isActive }) =>
-            `block truncate rounded-lg py-[6px] pr-[28px] pl-[12px] text-[16px] leading-[24px] font-normal text-[#6B7280] transition-colors ${
-              isActive ? "mr-[-6px] bg-[#EBEBEB]" : "hover:bg-[#F5F5F5]"
+            `block truncate rounded-lg py-[6px] pr-[28px] pl-[12px] text-[16px] leading-[24px] transition-colors ${
+              isActive
+                ? "mr-[-6px] bg-[#EBEBEB] font-medium text-black"
+                : "font-normal text-[#6B7280] hover:bg-[#F5F5F5] hover:text-black"
             }`
           }
         >
@@ -102,7 +104,7 @@ export const SidebarNoteItem = ({
       {!isRenaming && (
         <div
           ref={menuRef}
-          className="absolute top-1/2 right-1 -translate-y-1/2"
+          className="absolute top-1/2 right-[-6px] -translate-y-1/2"
         >
           <button
             onClick={(e) => {
@@ -142,25 +144,25 @@ export const SidebarNoteItem = ({
           </button>
 
           {isMenuOpen && (
-            <div className="absolute top-full right-0 z-50 mt-1 w-[120px] rounded-lg border border-[#E3E7ED] bg-white py-1 shadow-lg">
+            <div className="absolute top-full right-0 z-50 mt-1 flex w-[105px] flex-col items-center rounded-[8px] border-[0.5px] border-[#D1D6DE] bg-white p-[8px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.05)]">
               <button
                 onClick={() => {
                   setTitleInput(note.title);
                   setIsRenaming(true);
                   setIsMenuOpen(false);
                 }}
-                className="w-full px-3 py-[6px] text-left text-[13px] text-[#454545] hover:bg-[#F5F5F5]"
+                className="w-full rounded px-3 py-[6px] text-left text-[13px] leading-[24px] font-normal text-[#6B7280] transition-colors hover:text-black active:font-medium active:text-black"
               >
-                이름 변경
+                수정하기
               </button>
               <button
                 onClick={() => {
                   onDeleteRequest();
                   setIsMenuOpen(false);
                 }}
-                className="w-full px-3 py-[6px] text-left text-[13px] text-red-500 hover:bg-[#FFF5F5]"
+                className="w-full rounded px-3 py-[6px] text-left text-[13px] leading-[24px] font-normal text-[#6B7280] transition-colors hover:text-black active:font-medium active:text-black"
               >
-                삭제
+                삭제하기
               </button>
             </div>
           )}

--- a/src/features/sidebar/components/SidebarNoteItem.tsx
+++ b/src/features/sidebar/components/SidebarNoteItem.tsx
@@ -151,7 +151,7 @@ export const SidebarNoteItem = ({
                   setIsRenaming(true);
                   setIsMenuOpen(false);
                 }}
-                className="w-full rounded px-3 py-[6px] text-left text-[13px] leading-[24px] font-normal text-[#6B7280] transition-colors hover:text-black active:font-medium active:text-black"
+                className="w-full rounded px-3 py-[6px] text-center text-[13px] leading-[24px] font-normal text-[#6B7280] transition-colors hover:text-black active:font-medium active:text-black"
               >
                 수정하기
               </button>
@@ -160,7 +160,7 @@ export const SidebarNoteItem = ({
                   onDeleteRequest();
                   setIsMenuOpen(false);
                 }}
-                className="w-full rounded px-3 py-[6px] text-left text-[13px] leading-[24px] font-normal text-[#6B7280] transition-colors hover:text-black active:font-medium active:text-black"
+                className="w-full rounded px-3 py-[6px] text-center text-[13px] leading-[24px] font-normal text-[#6B7280] transition-colors hover:text-black active:font-medium active:text-black"
               >
                 삭제하기
               </button>

--- a/src/features/sidebar/components/SidebarNoteItem.tsx
+++ b/src/features/sidebar/components/SidebarNoteItem.tsx
@@ -90,7 +90,7 @@ export const SidebarNoteItem = ({
           to={`/app/chat/${note.noteId}`}
           state={{ chatEntrySource: "sidebar-recent-notes" }}
           className={({ isActive }) =>
-            `block truncate rounded-lg py-[6px] pr-[28px] pl-[12px] text-[16px] leading-[24px] transition-colors ${
+            `block truncate rounded-lg py-[3px] pr-[28px] pl-[12px] text-[16px] leading-[24px] transition-colors ${
               isActive
                 ? "mr-[-6px] bg-[#EBEBEB] font-medium text-black"
                 : "font-normal text-[#6B7280] hover:text-black"

--- a/src/features/sidebar/components/SidebarNoteItem.tsx
+++ b/src/features/sidebar/components/SidebarNoteItem.tsx
@@ -93,7 +93,7 @@ export const SidebarNoteItem = ({
             `block truncate rounded-lg py-[6px] pr-[28px] pl-[12px] text-[16px] leading-[24px] transition-colors ${
               isActive
                 ? "mr-[-6px] bg-[#EBEBEB] font-medium text-black"
-                : "font-normal text-[#6B7280] hover:bg-[#F5F5F5] hover:text-black"
+                : "font-normal text-[#6B7280] hover:text-black"
             }`
           }
         >

--- a/src/features/sidebar/components/SidebarProfile.tsx
+++ b/src/features/sidebar/components/SidebarProfile.tsx
@@ -87,7 +87,7 @@ export const SidebarProfile = ({
 
         {/* 유저 행 - UserIcon은 absolute로 분리해 깜빡임 방지, 여기선 spacer만 */}
         <div
-          className="ml-[18px] flex w-[200px] cursor-pointer items-center justify-between rounded-[12px] py-1 pr-2 transition-colors hover:bg-gray-100"
+          className="ml-[16px] flex w-[200px] cursor-pointer items-center justify-between rounded-[12px] py-1 pr-2 transition-colors hover:bg-gray-100"
           onClick={onSettingsClick}
         >
           <div className="flex items-center gap-2">
@@ -132,7 +132,7 @@ export const SidebarProfile = ({
       {/* ── UserIcon 단독 고정 (opacity 전환 없이 항상 동일 위치) ── */}
       <button
         type="button"
-        className="absolute bottom-[24px] left-[18px] cursor-pointer border-none bg-transparent p-0"
+        className="absolute bottom-[24px] left-[16px] cursor-pointer border-none bg-transparent p-0"
         onMouseEnter={() => setIsUserIconHovered(true)}
         onMouseLeave={() => setIsUserIconHovered(false)}
         onClick={(e) => {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #278 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🗑️ 코드 제거 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

사이드바 레이아웃

- 최근 노트 목록 ↔ 저장소 버튼 간격 52px → 24px 축소
- 접힌 사이드바 아이콘 좌우 여백 균등화 (NavItem/SearchButton 18px, expand·UserIcon 16px, 크레딧 버튼 6px)
- 펼친 사이드바 크레딧 카드 좌우 여백 20px 고정
- 노트 목록 아이템 스타일

- 기본: #6B7280 / font-weight 400
- 호버: 배경 없이 텍스트 #000으로 변경
- 선택(active): #000 / font-weight 500 + 기존 #EBEBEB 배경 유지
- 선택 시 위아래 패딩 6px → 3px 축소
- 미트볼 버튼 위치를 클릭 시 배경 오른쪽 끝(right-[-6px])에 정렬
- 드롭다운 UI

- 크기 width 105px, padding 8px, border-radius 8px, box-shadow 업데이트
- 버튼명 이름 변경 → 수정하기, 삭제 → 삭제하기로 변경
- 버튼 색상 노트 아이템과 동일하게 통일, 가운데 정렬 적용
- 버그 수정

- 삭제 확인 모달이 Divider 슬라이더 버튼 뒤에 가리는 문제 → createPortal로 document.body에 마운트해 stacking context 우회


## 📸 스크린샷 (UI 변경 시 필수)

| Before    | After     |
| --------- | --------- |
| 이전 화면 | 이후 화면 |

> UI 변경이 없는 경우 이 섹션을 삭제해주세요.

## ✅ 체크리스트

### 공통

- [ ] 셀프 리뷰를 완료했습니다
- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] `pnpm tsc --noEmit` 타입 체크를 통과했습니다
- [ ] 브랜치명 컨벤션을 준수했습니다 (`type/이슈번호-작업명`)

### UI/레이아웃 변경 시

- [ ] 태블릿(768px~) / 데스크탑(1280px~) / 와이드(1360px~) 반응형을 확인했습니다
- [ ] `PageContainer` / `ContentGrid` 공통 컴포넌트를 활용했습니다

### 캔버스 관련 변경 시

- [ ] Konva / perfect-freehand 드로잉 성능에 영향이 없음을 확인했습니다
- [ ] 캔버스 이벤트 스트림(onPointerDown/Move/Up)이 정상 동작합니다

### 인증 관련 변경 시

- [ ] 카카오 / 네이버 로그인 흐름에 영향이 없음을 확인했습니다
- [ ] 토큰 갱신 및 로그아웃 흐름을 확인했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
- 사이드바 메뉴 영역의 간격을 조정하여 레이아웃 개선
- 노트 항목 드롭다운 메뉴의 디자인 및 버튼 텍스트 업데이트
- 프로필 섹션의 위치 정렬 개선

## 버그 수정
- 삭제 확인 모달의 표시 처리 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Proovy/Proovy-front/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->