### PR TITLE
Feat(#292): react-query 전역 mutation 에러 토스트 안전망 추가

### DIFF
--- a/src/app/providers/query_provider.tsx
+++ b/src/app/providers/query_provider.tsx
@@ -1,19 +1,76 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  MutationCache,
+} from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import type { PropsWithChildren } from "react";
 import { useState } from "react";
+import axios from "axios";
+import { showErrorToast } from "@/shared/lib/toast";
+import { getErrorRedirectRoute } from "@/shared/api/client";
+
+/**
+ * react-query mutation meta 타입 보강.
+ * - suppressGlobalErrorToast: 호출부에서 직접 에러를 표시하는 경우 전역 토스트를 끔
+ * - errorMessage: 전역 토스트에 표시할 커스텀 메시지
+ */
+declare module "@tanstack/react-query" {
+  interface Register {
+    mutationMeta: {
+      suppressGlobalErrorToast?: boolean;
+      errorMessage?: string;
+    };
+  }
+}
+
+const DEFAULT_ERROR_MESSAGE =
+  "요청 처리 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.";
+
+/** 에러에서 사용자에게 보여줄 메시지를 안전하게 추출 (원시 기술 메시지 노출 방지) */
+const resolveErrorMessage = (error: unknown, override?: string): string => {
+  if (override) return override;
+  if (axios.isAxiosError(error)) {
+    const serverMessage = (
+      error.response?.data as { message?: string } | undefined
+    )?.message;
+    if (serverMessage) return serverMessage;
+  }
+  return DEFAULT_ERROR_MESSAGE;
+};
 
 export function AppQueryProvider({ children }: PropsWithChildren) {
   // QueryClient는 한 번만 생성되도록 state로 관리 (SSR 고려 시 필수 패턴)
   const [queryClient] = useState(
     () =>
       new QueryClient({
+        // 개별 처리되지 않은 mutation 실패에 대한 전역 에러 토스트 안전망
+        mutationCache: new MutationCache({
+          onError: (error, _variables, _context, mutation) => {
+            // 호출부에서 자체 에러 UI를 표시하는 경우 옵트아웃
+            if (mutation.meta?.suppressGlobalErrorToast) return;
+            // 에러 페이지로 리다이렉트되는 에러는 토스트가 중복되므로 생략
+            if (getErrorRedirectRoute(error)) return;
+
+            showErrorToast(
+              resolveErrorMessage(error, mutation.meta?.errorMessage),
+            );
+          },
+        }),
         defaultOptions: {
           queries: {
             // 창 포커스 시 자동 재요청 방지 (개발 편의성)
             refetchOnWindowFocus: false,
             // 데이터가 '오래된(stale)' 상태로 간주되는 시간 (1분)
             staleTime: 1000 * 60,
+            // 4xx(클라이언트 에러)는 재시도 무의미 → 비재시도, 그 외만 2회 재시도
+            retry: (failureCount, error) => {
+              if (axios.isAxiosError(error)) {
+                const status = error.response?.status;
+                if (status && status >= 400 && status < 500) return false;
+              }
+              return failureCount < 2;
+            },
           },
         },
       }),

--- a/src/features/notes/hooks/useNotes.ts
+++ b/src/features/notes/hooks/useNotes.ts
@@ -73,6 +73,8 @@ export const useCreateNote = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // useHomeSend에서 자체 onError 토스트로 처리 → 전역 토스트 제외
+    meta: { suppressGlobalErrorToast: true },
     mutationFn: (
       variables: CreateNoteRequest & { suppressRedirect?: boolean },
     ) => {
@@ -140,6 +142,8 @@ export const useDeleteNotesBulk = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // DeleteNotesModal에서 인라인 에러 메시지로 처리 → 전역 토스트 제외
+    meta: { suppressGlobalErrorToast: true },
     mutationFn: (noteIds: number[]) => deleteNotesBulk(noteIds),
     onSuccess: () => {
       // 노트 목록 캐시 무효화

--- a/src/features/settings/hooks/useCredit.ts
+++ b/src/features/settings/hooks/useCredit.ts
@@ -31,6 +31,8 @@ export const useUseCredit = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // ChatInput에서 크레딧 부족 등을 자체 토스트로 처리 + 낙관적 롤백 → 전역 토스트 제외
+    meta: { suppressGlobalErrorToast: true },
     mutationFn: useCredit,
     onMutate: async (variables: CreditUsageRequest) => {
       await queryClient.cancelQueries({ queryKey: userKeys.profile() });

--- a/src/features/settings/hooks/useUser.ts
+++ b/src/features/settings/hooks/useUser.ts
@@ -60,6 +60,8 @@ export const useCancelSubscription = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // SubscriptionTabContent에서 자체 토스트로 처리 → 전역 토스트 제외
+    meta: { suppressGlobalErrorToast: true },
     mutationFn: cancelSubscription,
     onSuccess: (response) => {
       if (response.isSuccess) {
@@ -75,6 +77,8 @@ export const useUpgradeSubscription = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // PricingPage에서 자체 토스트로 처리 → 전역 토스트 제외
+    meta: { suppressGlobalErrorToast: true },
     mutationFn: (data: UpgradeSubscriptionRequest) => upgradeSubscription(data),
     onSuccess: (response) => {
       if (response.isSuccess) {
@@ -90,6 +94,8 @@ export const useResumeSubscription = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // SubscriptionTabContent에서 자체 토스트로 처리 → 전역 토스트 제외
+    meta: { suppressGlobalErrorToast: true },
     mutationFn: resumeSubscription,
     onSuccess: (response) => {
       if (response.isSuccess) {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -70,6 +70,16 @@ const resolveErrorRoute = (error: AxiosError) => {
   return null;
 };
 
+/**
+ * 주어진 에러가 에러 페이지 리다이렉트를 유발하는지 판단해 그 경로를 반환한다.
+ * (전역 에러 토스트가 리다이렉트와 중복 표시되지 않도록 판단하는 용도)
+ */
+export const getErrorRedirectRoute = (error: unknown): string | null => {
+  if (!SHOULD_ENABLE_ERROR_REDIRECT) return null;
+  if (!axios.isAxiosError(error)) return null;
+  return resolveErrorRoute(error);
+};
+
 // 토큰 관리 유틸
 export const tokenUtils = {
   getAccessToken: () => localStorage.getItem(ACCESS_TOKEN_KEY),


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #292

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🗑️ 코드 제거 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

개별 처리되지 않은 mutation 실패가 **조용히 사라지던 문제**를 막기 위해 react-query 전역 에러 토스트 안전망을 추가했습니다.

- `MutationCache.onError` 추가 → 개별 처리되지 않은 mutation 실패를 자동으로 에러 토스트 표시
- **중복 토스트 방지**
  - `meta.suppressGlobalErrorToast` 옵트아웃 → 호출부에서 자체 에러 UI를 표시하는 mutation은 제외
  - 에러 페이지로 리다이렉트되는 에러(5xx 등)는 토스트 생략 (`getErrorRedirectRoute`)
- **원시 기술 메시지 노출 방지** → `meta.errorMessage` → 서버 `message` → 안전한 기본 문구 순으로 추출
- **쿼리 retry 정책** → 4xx(클라이언트 에러)는 비재시도, 그 외만 2회 재시도
- react-query `mutationMeta` 타입 보강
- `client.ts`: `getErrorRedirectRoute()` 헬퍼 export (기존 리다이렉트 판단 로직 재사용)

### 옵트아웃 처리한 mutation (자체 피드백 존재 → 중복 방지)
| Mutation | 사유 |
| --- | --- |
| `useUseCredit` | ChatInput 자체 토스트 + 낙관적 롤백 |
| `useCancelSubscription` / `useResumeSubscription` | SubscriptionTabContent 자체 토스트 |
| `useUpgradeSubscription` | PricingPage 자체 토스트 |
| `useDeleteNotesBulk` | DeleteNotesModal 인라인 에러 |
| `useCreateNote` | useHomeSend 자체 onError 토스트 |

### 새로 안전망이 적용된 곳 (기존엔 조용히 실패)
- `useDeleteNote`(RecentNotes), `useUpdateNoteTitle`(SidebarNoteItem)의 `catch {}` → 이제 실패 시 토스트 표시

## ✅ 체크리스트

### 공통

- [x] 셀프 리뷰를 완료했습니다
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] `pnpm tsc --noEmit` 타입 체크를 통과했습니다
- [x] 브랜치명 컨벤션을 준수했습니다 (`type/이슈번호-작업명`)

## 📎 기타 참고사항

- 동작 확인: 미처리 mutation(노트 이름 변경)을 임시로 실패시켜 우측 상단 에러 토스트 표시를 로컬에서 검증했습니다.
- 5xx 리다이렉트 vs 토스트의 **세부 정책 정리는 #293**에서 다룰 예정이며, 본 PR은 '중복 방지' 수준만 포함합니다.
- 쿼리 에러는 토스트가 과도해질 수 있어(백그라운드 refetch 등) 전역 토스트 대상에서 제외하고 retry 정책만 조정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 에러 발생 시 중복된 에러 메시지 표시를 방지하도록 개선했습니다.
  * 특정 작업에서 불필요한 에러 알림을 억제하여 사용자 경험을 개선했습니다.
  * 에러 메시지 표시 로직을 안정적으로 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->